### PR TITLE
Optional dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     langchainrb (0.3.1)
-      cohere-ruby (~> 0.9.3)
       eqn (~> 1.6.5)
       google_search_results (~> 2.0.0)
       milvus (~> 0.9.0)
@@ -209,6 +208,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  cohere-ruby (~> 0.9.3)
   dotenv-rails (~> 2.7.6)
   langchainrb!
   pry-byebug (~> 3.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     minitest (5.18.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
+    nokogiri (1.14.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
@@ -204,6 +206,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-19
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ openai.complete(prompt: "What is the meaning of life?")
 ```
 
 #### Cohere
+Add `gem "cohere-ruby", "~> 0.9.3"` to your Gemfile.
+
 ```ruby
 cohere = LLM::Cohere.new(api_key: ENV["COHERE_API_KEY"])
 ```

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "pry-byebug", "~> 3.10.0"
+  spec.add_development_dependency "cohere-ruby", "~> 0.9.3"
   spec.add_development_dependency "dotenv-rails", "~> 2.7.6"
+  spec.add_development_dependency "pry-byebug", "~> 3.10.0"
 
-  spec.add_dependency "cohere-ruby", "~> 0.9.3"
   spec.add_dependency "eqn", "~> 1.6.5"
   spec.add_dependency "milvus", "~> 0.9.0"
   spec.add_dependency "pinecone", "~> 0.1.6"

--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "./version"
+require_relative "./optional_dependency_helper"
 
 module Agent
   autoload :Base, "agent/base"

--- a/lib/llm/cohere.rb
+++ b/lib/llm/cohere.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-require "cohere"
-
 module LLM
   class Cohere < Base
-
     DEFAULTS = {
       temperature: 0.0,
       completion_model_name: "base",
@@ -13,6 +10,8 @@ module LLM
     }.freeze
 
     def initialize(api_key:)
+      require_optional_dependency "cohere-ruby"
+
       @client = ::Cohere::Client.new(api_key: api_key)
     end
 

--- a/lib/optional_dependency_helper.rb
+++ b/lib/optional_dependency_helper.rb
@@ -3,6 +3,8 @@
 def require_optional_dependency(name)
   gem name # require the gem
 
+  return unless defined?(Bundler) # If we're in a non-bundler environment, we're no longer able to determine if we'll meet requirements
+
   gem_version = Gem.loaded_specs[name].version
   gem_requirement = Bundler.load.dependencies.find { |g| g.name == name }.requirement
 

--- a/lib/optional_dependency_helper.rb
+++ b/lib/optional_dependency_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+def require_optional_dependency(name)
+  gem name # require the gem
+
+  gem_version = Gem.loaded_specs[name].version
+  gem_requirement = Bundler.load.dependencies.find { |g| g.name == name }.requirement
+
+  if !gem_requirement.satisfied_by?(gem_version)
+    raise "The #{name} gem is installed, but version #{gem_requirement} is required. You have #{gem_version}."
+  end
+rescue LoadError
+  raise LoadError, "Could not load #{name}. Please ensure that the #{name} gem is installed."
+end

--- a/spec/llm/cohere_spec.rb
+++ b/spec/llm/cohere_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "cohere"
+
 RSpec.describe LLM::Cohere do
   let(:subject) { described_class.new(api_key: "123") }
 


### PR DESCRIPTION
This PR provides a helper to "require" the gem into the project... but only if it's in already in the Gemfile, otherwise it raises a semi-helpful error message.

In order for this to work, the dependency still needs to be a development dependency (i.e. `spec.add_development_dependency`) in the gemspec

Works on #3 