### PR TITLE
Escape double curly braces in prompt template strings

### DIFF
--- a/lib/prompt/base.rb
+++ b/lib/prompt/base.rb
@@ -74,9 +74,9 @@ module Prompt
       input_variables = []
       scanner = StringScanner.new(template)
 
-      while scanner.scan_until(/\{([^{}]*)\}/)
+      while scanner.scan_until(/\{([^}]*)\}/)
         variable = scanner[1].strip
-        input_variables << variable unless variable.empty?
+        input_variables << variable unless variable.empty? || variable[0] == "{"
       end
 
       input_variables

--- a/lib/prompt/base.rb
+++ b/lib/prompt/base.rb
@@ -66,6 +66,8 @@ module Prompt
     # contained within the template. Input variables are defined as text enclosed in
     # curly braces (e.g. "{variable_name}").
     #
+    # Content within two consecutive curly braces (e.g. "{{ignore_me}}) are ignored.
+    #
     # @param template [String] The template string to extract variables from.
     #
     # @return [Array<String>] An array of input variable names.

--- a/lib/prompt/prompt_template.rb
+++ b/lib/prompt/prompt_template.rb
@@ -20,7 +20,7 @@ module Prompt
     end
 
     #
-    # Format the prompt with the inputs.
+    # Format the prompt with the inputs. Double {{}} replaced with single {} to adhere to f-string spec.
     #
     # @param kwargs [Hash] Any arguments to be passed to the prompt template.
     # @return [String] A formatted string.
@@ -28,7 +28,7 @@ module Prompt
     def format(**kwargs)
       result = @template
       kwargs.each { |key, value| result = result.gsub(/\{#{key}\}/, value.to_s) }
-      result.gsub(/{{/, '{').gsub(/}}/, '}')
+      result.gsub(/{{/, "{").gsub(/}}/, "}")
     end
 
     #

--- a/lib/prompt/prompt_template.rb
+++ b/lib/prompt/prompt_template.rb
@@ -28,7 +28,7 @@ module Prompt
     def format(**kwargs)
       result = @template
       kwargs.each { |key, value| result = result.gsub(/\{#{key}\}/, value.to_s) }
-      result
+      result.gsub(/{{/, '{').gsub(/}}/, '}')
     end
 
     #

--- a/spec/prompts/base_spec.rb
+++ b/spec/prompts/base_spec.rb
@@ -34,4 +34,19 @@ RSpec.describe Prompt::Base do
       expect(File.directory?(non_existent_dir)).to be_truthy
     end
   end
+
+  describe "#extract_variables_from_template" do
+    let(:basic_template) { "Tell me a {adjective} joke." }
+    let(:escaped_template) { "Tell me a {adjective} joke. Return in JSON in the format {{joke: 'The joke'}}" }
+    
+    it "extracts variables" do
+      input_variables = Prompt::Base.extract_variables_from_template(basic_template)
+      expect(input_variables).to eq(%w[adjective])
+    end
+
+    it "excludes double curly brace variables" do
+      input_variables = Prompt::Base.extract_variables_from_template(escaped_template)
+      expect(input_variables).to eq(%w[adjective])
+    end
+  end
 end

--- a/spec/prompts/base_spec.rb
+++ b/spec/prompts/base_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Prompt::Base do
   describe "#extract_variables_from_template" do
     let(:basic_template) { "Tell me a {adjective} joke." }
     let(:escaped_template) { "Tell me a {adjective} joke. Return in JSON in the format {{joke: 'The joke'}}" }
-    
+
     it "extracts variables" do
       input_variables = Prompt::Base.extract_variables_from_template(basic_template)
       expect(input_variables).to eq(%w[adjective])


### PR DESCRIPTION
Resolves #42 

---
Simple approach to not include input variables denoted by double curly braces. As per the f-string syntax double curly braces are replaces by single curly braces in the output.

```ruby
prompt = Prompt::PromptTemplate.new(template: "Tell me a {adjective} joke. Return in JSON in the format {{joke: 'The joke'}}", input_variables: ["adjective"])
prompt.format
=> "Tell me a {adjective} joke. Return in JSON in the format {joke: 'The joke'}"
irb(main):006:0>
```

Tested via new spec and also ran against all current Prompt examples on langchain-hub to ensure compatibility with wider ecosystem.