### PR TITLE
Better Dependency checking

### DIFF
--- a/lib/dependency_helper.rb
+++ b/lib/dependency_helper.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+VersionError = Class.new(ScriptError)
+
 # This method requires and loads the given gem, and then checks to see if the version of the gem meets the requirements listed in `langchain.gemspec`
 # This solution was built to avoid auto-loading every single gem in the Gemfile when the developer will mostly likely be only using a few of them.
 #
 # @param gem_name [String] The name of the gem to load
 # @return [Boolean] Whether or not the gem was loaded successfully
 # @raise [LoadError] If the gem is not installed
-# @raise [LoadError] If the gem is installed, but the version does not meet the requirements
+# @raise [VersionError] If the gem is installed, but the version does not meet the requirements
 #
 def depends_on(gem_name)
   gem(gem_name) # require the gem
@@ -16,10 +18,10 @@ def depends_on(gem_name)
   gem_version = Gem.loaded_specs[gem_name].version
   gem_requirement = Bundler.load.dependencies.find { |g| g.name == gem_name }&.requirement
 
-  raise LoadError if !gem_requirement
+  raise LoadError unless gem_requirement
 
-  if !gem_requirement.satisfied_by?(gem_version)
-    raise "The #{gem_name} gem is installed, but version #{gem_requirement} is required. You have #{gem_version}."
+  unless gem_requirement.satisfied_by?(gem_version)
+    raise VersionError, "The #{gem_name} gem is installed, but version #{gem_requirement} is required. You have #{gem_version}."
   end
 
   true

--- a/lib/dependency_helper.rb
+++ b/lib/dependency_helper.rb
@@ -14,7 +14,9 @@ def depends_on(gem_name)
   return(true) unless defined?(Bundler) # If we're in a non-bundler environment, we're no longer able to determine if we'll meet requirements
 
   gem_version = Gem.loaded_specs[gem_name].version
-  gem_requirement = Bundler.load.dependencies.find { |g| g.name == gem_name }.requirement
+  gem_requirement = Bundler.load.dependencies.find { |g| g.name == gem_name }&.requirement
+
+  raise LoadError if !gem_requirement
 
   if !gem_requirement.satisfied_by?(gem_version)
     raise "The #{gem_name} gem is installed, but version #{gem_requirement} is required. You have #{gem_version}."

--- a/spec/dependency_helper_spec.rb
+++ b/spec/dependency_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "depends_on" do
+  it "doesn't raise an error if the gem is included" do
+    expect { depends_on("rspec") }.not_to raise_error
+  end
+
+  it "raises raise if the gem isn't included" do
+    expect { depends_on("random-gem") }.to raise_error(LoadError, /Could not load random-gem/)
+  end
+
+  it "when doesn't have it as a bundler dependency" do
+    bundler_load = double(:load, dependencies: [])
+    allow(Bundler).to receive(:load).and_return(bundler_load)
+
+    expect { depends_on("rspec") }.to raise_error(LoadError, /Could not load rspec/)
+  end
+
+  it "when doesn't match Gem version requirement" do
+    gem_loaded_spec = double(:specs, "[]": double(:version, version: Gem::Version.new("0.1")))
+    allow(Gem).to receive(:loaded_specs).and_return(gem_loaded_spec)
+
+    expect { depends_on("rspec") }.to raise_error(VersionError, /The rspec gem is installed.*You have 0.1/)
+  end
+end


### PR DESCRIPTION
There appear to be some cases where our `depends_on` helper doesn't properly determine if a gem has been installed.