### PR TITLE
Add Langchain::Data result object for data loaders

### DIFF
--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -17,6 +17,7 @@ module Langchain
   @root = Pathname.new(__dir__)
 
   autoload :Loader, "langchain/loader"
+  autoload :Data, "langchain/data"
 
   module Processors
     autoload :Base, "langchain/processors/base"

--- a/lib/langchain/data.rb
+++ b/lib/langchain/data.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Langchain
+  class Data
+    attr_reader :source
+
+    def initialize(data, options = {})
+      @source = options[:source]
+      @data = data
+    end
+
+    def value
+      @data
+    end
+  end
+end

--- a/lib/langchain/loader.rb
+++ b/lib/langchain/loader.rb
@@ -58,11 +58,12 @@ module Langchain
     end
 
     def process(&block)
-      data, processor = yield
+      raw_data, kind = yield
 
-      raise UnknownFormatError unless processor
+      raise UnknownFormatError unless kind
 
-      Langchain::Processors.const_get(processor).new.parse(data)
+      processor = Langchain::Processors.const_get(kind).new
+      Langchain::Data.new(processor.parse(raw_data), source: @path)
     end
 
     def find_processor(constant, value)

--- a/lib/vectorsearch/base.rb
+++ b/lib/vectorsearch/base.rb
@@ -74,7 +74,7 @@ module Vectorsearch
 
       texts = Array(path || paths)
         .flatten
-        .map { |path| Langchain::Loader.new(path)&.load }
+        .map { |path| Langchain::Loader.new(path)&.load&.value }
         .compact
 
       add_texts(texts: texts)

--- a/spec/langchain/loader_spec.rb
+++ b/spec/langchain/loader_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Langchain::Loader do
         let(:path) { "spec/fixtures/loaders/example.txt" }
 
         it "loads text from file" do
-          expect(subject).to include("Lorem Ipsum")
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to include("Lorem Ipsum")
         end
       end
 
@@ -26,7 +27,8 @@ RSpec.describe Langchain::Loader do
         let(:path) { "http://example.com/example.txt" }
 
         it "loads text from URL" do
-          expect(subject).to eq("Lorem Ipsum")
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to eq("Lorem Ipsum")
         end
       end
     end
@@ -36,7 +38,8 @@ RSpec.describe Langchain::Loader do
         let(:path) { "spec/fixtures/loaders/example.html" }
 
         it "loads text from file" do
-          expect(subject).to eq("Lorem Ipsum\n\nDolor sit amet.")
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to eq("Lorem Ipsum\n\nDolor sit amet.")
         end
       end
 
@@ -46,7 +49,8 @@ RSpec.describe Langchain::Loader do
         let(:content_type) { "text/html" }
 
         it "loads text from URL" do
-          expect(subject).to eq("Lorem Ipsum\n\nDolor sit amet.")
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to eq("Lorem Ipsum\n\nDolor sit amet.")
         end
       end
     end
@@ -56,12 +60,13 @@ RSpec.describe Langchain::Loader do
         let(:path) { "spec/fixtures/loaders/cairo-unicode.pdf" }
 
         it "loads text from file" do
-          expect(subject).to include("UTF-8 encoded sample plain-text file")
-          expect(subject).to include("The ASCII compatible UTF-8 encoding used in this plain-text file")
-          expect(subject).to include("The Greek anthem:")
-          expect(subject).to include("τελευτῆς ὁντινοῦν ποιεῖσθαι λόγον.")
-          expect(subject).to include("Proverbs in the Amharic language")
-          expect(subject).to include("ወዳጅህ ማር ቢሆን ጨርስህ አትላሰው።")
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to include("UTF-8 encoded sample plain-text file")
+          expect(subject.value).to include("The ASCII compatible UTF-8 encoding used in this plain-text file")
+          expect(subject.value).to include("The Greek anthem:")
+          expect(subject.value).to include("τελευτῆς ὁντινοῦν ποιεῖσθαι λόγον.")
+          expect(subject.value).to include("Proverbs in the Amharic language")
+          expect(subject.value).to include("ወዳጅህ ማር ቢሆን ጨርስህ አትላሰው።")
         end
       end
 
@@ -71,12 +76,13 @@ RSpec.describe Langchain::Loader do
         let(:content_type) { "application/pdf" }
 
         it "loads text from URL" do
-          expect(subject).to include("UTF-8 encoded sample plain-text file")
-          expect(subject).to include("The ASCII compatible UTF-8 encoding used in this plain-text file")
-          expect(subject).to include("The Greek anthem:")
-          expect(subject).to include("τελευτῆς ὁντινοῦν ποιεῖσθαι λόγον.")
-          expect(subject).to include("Proverbs in the Amharic language")
-          expect(subject).to include("ወዳጅህ ማር ቢሆን ጨርስህ አትላሰው።")
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to include("UTF-8 encoded sample plain-text file")
+          expect(subject.value).to include("The ASCII compatible UTF-8 encoding used in this plain-text file")
+          expect(subject.value).to include("The Greek anthem:")
+          expect(subject.value).to include("τελευτῆς ὁντινοῦν ποιεῖσθαι λόγον.")
+          expect(subject.value).to include("Proverbs in the Amharic language")
+          expect(subject.value).to include("ወዳጅህ ማር ቢሆን ጨርስህ አትላሰው።")
         end
       end
     end
@@ -86,7 +92,8 @@ RSpec.describe Langchain::Loader do
         let(:path) { "spec/fixtures/loaders/sample.docx" }
 
         it "loads text from file" do
-          expect(subject).to include("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ac faucibus odio.")
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to include("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ac faucibus odio.")
         end
       end
 
@@ -96,7 +103,8 @@ RSpec.describe Langchain::Loader do
         let(:content_type) { "application/vnd.openxmlformats-officedocument.wordprocessingml.document" }
 
         it "loads text from URL" do
-          expect(subject).to include("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ac faucibus odio.")
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to include("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ac faucibus odio.")
         end
       end
     end
@@ -117,7 +125,8 @@ RSpec.describe Langchain::Loader do
         let(:path) { "spec/fixtures/loaders/example.csv" }
 
         it "loads text from file" do
-          expect(subject).to eq(result)
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to eq(result)
         end
       end
 
@@ -127,7 +136,8 @@ RSpec.describe Langchain::Loader do
         let(:content_type) { "text/csv" }
 
         it "loads text from URL" do
-          expect(subject).to eq(result)
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to eq(result)
         end
       end
     end
@@ -141,7 +151,8 @@ RSpec.describe Langchain::Loader do
         let(:path) { "spec/fixtures/loaders/example.json" }
 
         it "loads text from file" do
-          expect(subject).to include(result)
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to include(result)
         end
       end
 
@@ -151,7 +162,8 @@ RSpec.describe Langchain::Loader do
         let(:body) { File.read("spec/fixtures/loaders/example.json") }
 
         it "loads text from URL" do
-          expect(subject).to include(result)
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to include(result)
         end
       end
     end
@@ -170,7 +182,8 @@ RSpec.describe Langchain::Loader do
         let(:path) { "spec/fixtures/loaders/example.jsonl" }
 
         it "loads text from file" do
-          expect(subject).to eq(result)
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to eq(result)
         end
       end
 
@@ -180,7 +193,8 @@ RSpec.describe Langchain::Loader do
         let(:body) { File.read("spec/fixtures/loaders/example.jsonl") }
 
         it "loads text from URL" do
-          expect(subject).to eq(result)
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to eq(result)
         end
       end
     end


### PR DESCRIPTION
## Motivation
Data comes in different types and formats. Sometimes file (URL) content is not the only useful data that we can return from a loader. In order to also return metadata, info about the number of pages in a document, etc, we need a more sophisticated data structure than just plain text.

## Changes
- Add a simple wrapper class for the data returned by the loader `Langchain::Data` with a `value` method that returns actual data: text, binary, etc.
- Update `Langchain::Loader` to return an instance of `Langchain::Data`
- Update `Vectorsearch::Base` to call `value` method on loaded data result
- Update specs