### PR TITLE
Allow passing custom processor as a block to a loader

### DIFF
--- a/lib/langchain/loader.rb
+++ b/lib/langchain/loader.rb
@@ -39,10 +39,10 @@ module Langchain
     def load(&block)
       @raw_data = url? ? load_from_url : load_from_path
 
-      if block_given?
-        data = yield @raw_data.read, @options
+      data = if block
+        yield @raw_data.read, @options
       else
-        data = processor_klass.new(@options).parse(@raw_data)
+        processor_klass.new(@options).parse(@raw_data)
       end
 
       Langchain::Data.new(data, source: @path)
@@ -61,7 +61,7 @@ module Langchain
     end
 
     def processor_klass
-      raise UnknownFormatError unless kind = find_processor
+      raise UnknownFormatError unless (kind = find_processor)
 
       Langchain::Processors.const_get(kind)
     end
@@ -83,7 +83,7 @@ module Langchain
     end
 
     def lookup_constant
-      constant = url? ? :CONTENT_TYPES : :EXTENSIONS
+      url? ? :CONTENT_TYPES : :EXTENSIONS
     end
   end
 end

--- a/lib/langchain/processors/base.rb
+++ b/lib/langchain/processors/base.rb
@@ -6,6 +6,10 @@ module Langchain
       EXTENSIONS = []
       CONTENT_TYPES = []
 
+      def initialize(options = {})
+        @options = options
+      end
+
       def parse(data)
         raise NotImplementedError
       end

--- a/lib/langchain/processors/csv.rb
+++ b/lib/langchain/processors/csv.rb
@@ -12,9 +12,15 @@ module Langchain
       # @param [File] data
       # @return [Array of Hash]
       def parse(data)
-        ::CSV.new(data.read).map do |row|
+        ::CSV.new(data.read, col_sep: separator).map do |row|
           row.map(&:strip)
         end
+      end
+
+      private
+
+      def separator
+        @options[:col_sep] || ","
       end
     end
   end

--- a/lib/langchain/processors/docx.rb
+++ b/lib/langchain/processors/docx.rb
@@ -6,7 +6,7 @@ module Langchain
       EXTENSIONS = [".docx"]
       CONTENT_TYPES = ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"]
 
-      def initialize
+      def initialize(*)
         depends_on "docx"
         require "docx"
       end

--- a/lib/langchain/processors/html.rb
+++ b/lib/langchain/processors/html.rb
@@ -9,7 +9,7 @@ module Langchain
       # We only look for headings and paragraphs
       TEXT_CONTENT_TAGS = %w[h1 h2 h3 h4 h5 h6 p]
 
-      def initialize
+      def initialize(*)
         depends_on "nokogiri"
         require "nokogiri"
       end

--- a/lib/langchain/processors/pdf.rb
+++ b/lib/langchain/processors/pdf.rb
@@ -6,7 +6,7 @@ module Langchain
       EXTENSIONS = [".pdf"]
       CONTENT_TYPES = ["application/pdf"]
 
-      def initialize
+      def initialize(*)
         depends_on "pdf-reader"
         require "pdf-reader"
       end

--- a/spec/fixtures/loaders/semicolon_example.csv
+++ b/spec/fixtures/loaders/semicolon_example.csv
@@ -1,0 +1,6 @@
+Username;Identifier;First name;Last name
+booker12;9012;Rachel;Booker
+grey07;2070;Laura;Grey
+johnson81;4081;Craig;Johnson
+jenkins46;9346;Mary;Jenkins
+smith79;5079;Jamie;Smith

--- a/spec/langchain/loader_spec.rb
+++ b/spec/langchain/loader_spec.rb
@@ -199,6 +199,30 @@ RSpec.describe Langchain::Loader do
       end
     end
 
+    context "Custom processor passed as block" do
+      subject do
+        described_class.new(path).load { |text| text.reverse }
+      end
+
+      context "from local file" do
+        let(:path) { "spec/fixtures/loaders/example.txt" }
+
+        it "returns data processed with custom processor" do
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to include("muspI meroL")
+        end
+      end
+
+      context "from url" do
+        let(:path) { "http://example.com/example.txt" }
+
+        it "loads text from URL" do
+          expect(subject).to be_a(Langchain::Data)
+          expect(subject.value).to eq("muspI meroL")
+        end
+      end
+    end
+
     context "Unsupported file type" do
       context "from local file" do
         let(:path) { "spec/fixtures/loaders/example.swf" }

--- a/spec/langchain/loader_spec.rb
+++ b/spec/langchain/loader_spec.rb
@@ -122,11 +122,25 @@ RSpec.describe Langchain::Loader do
       end
 
       context "from local file" do
-        let(:path) { "spec/fixtures/loaders/example.csv" }
+        context "with default options" do
+          let(:path) { "spec/fixtures/loaders/example.csv" }
 
-        it "loads text from file" do
-          expect(subject).to be_a(Langchain::Data)
-          expect(subject.value).to eq(result)
+          it "loads data from file" do
+            expect(subject).to be_a(Langchain::Data)
+            expect(subject.value).to eq(result)
+          end
+        end
+
+        context "with custom options" do
+          let(:path) { "spec/fixtures/loaders/semicolon_example.csv" }
+          let(:options) { {col_sep: ";"} }
+
+          subject { described_class.new(path, options).load }
+
+          it "loads data from csv file separated by semicolon" do
+            expect(subject).to be_a(Langchain::Data)
+            expect(subject.value).to eq(result)
+          end
         end
       end
 
@@ -135,7 +149,7 @@ RSpec.describe Langchain::Loader do
         let(:body) { File.read("spec/fixtures/loaders/example.csv") }
         let(:content_type) { "text/csv" }
 
-        it "loads text from URL" do
+        it "loads data from URL" do
           expect(subject).to be_a(Langchain::Data)
           expect(subject.value).to eq(result)
         end


### PR DESCRIPTION
## Motivation
1. Loaders need the ability to pass options to processors. Example: CSV processor works with coma-separated columns by default. But fails to parse semicolons correctly. A way to pass a `col_sep` option to `CSV.new` within a processor should exist.
2. If no processor for a specific file format exists there's currently no way to load and process this file. By passing a block to `load` method user should be able specify a custom processor for a particular load call.

## Changes
1. Allow `Langchain::Loader` to accept both `options` hash and a block. A call can now look like this:

**Passing an option**:
```ruby
Langchain::Loader.load(path, { col_sep: ';' })
```
or
```ruby
Langchain::Loader.new(path, { col_sep: ';').load
```
**Passing a block**

```ruby
Langchain::Loader.load(path) do |data|
  run_custom_processing(data)
end
```
or 

```ruby
Langchain::Loader.new(path).load do |data|
  run_custom_processing(data)
end
```
2. Accept `col_sep` option within CSV processor so that different separators are accepted within `csv` files