### PR TITLE
Switch the default operator to cosine distance for pgvector

### DIFF
--- a/spec/vectorsearch/pgvector_spec.rb
+++ b/spec/vectorsearch/pgvector_spec.rb
@@ -102,6 +102,14 @@ if ENV["POSTGRES_URL"]
         expect(result.length).to eq(4)
         expect(result[0]["content"]).to eq("Some valuable data")
       end
+
+      it "should use the cosine distance operator by default" do
+        expect_any_instance_of(PG::Connection).to receive(:exec_params) do |_, query|
+          expect(query).to include("ORDER BY vectors <=> $1")
+          []
+        end
+        subject.similarity_search_by_vector(embedding: 1536.times.map { 0 })
+      end
     end
 
     describe "#ask" do


### PR DESCRIPTION
Fixes #86

I've switched the operator to cosine distance (<=>) and added a test.

I've put the operators into a constant with a proper naming, since `<=>` is not very explicit.

I'm wondering if we want to give the option to change the operator, maybe in the **constructor**?

Something like:

```ruby
vector_store = Vectorsearch::Pgvector.new(url: ENV['POSTGRES_URL'], operator: 'euclidean_distance')
...
```