### PR TITLE
Add support for passing additional parameters to OpenAI client constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Add `gem "ruby-openai", "~> 4.0.0"` to your Gemfile.
 ```ruby
 openai = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
 ```
+You can pass additional parameters to the constructor, it will be passed to the OpenAI client:
+```ruby
+openai = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"], llm_options: {uri_base: "http://localhost:1234"}) )
+```
 ```ruby
 openai.embed(text: "foo bar")
 ```

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -10,12 +10,12 @@ module Langchain::LLM
       dimension: 1536
     }.freeze
 
-    def initialize(api_key:)
+    def initialize(api_key:, llm_options: {})
       depends_on "ruby-openai"
       require "openai"
 
       # TODO: Add support to pass `organization_id:`
-      @client = ::OpenAI::Client.new(access_token: api_key)
+      @client = ::OpenAI::Client.new(access_token: api_key, **llm_options)
     end
 
     #

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -14,7 +14,6 @@ module Langchain::LLM
       depends_on "ruby-openai"
       require "openai"
 
-      # TODO: Add support to pass `organization_id:`
       @client = ::OpenAI::Client.new(access_token: api_key, **llm_options)
     end
 

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -3,6 +3,27 @@
 RSpec.describe Langchain::LLM::OpenAI do
   let(:subject) { described_class.new(api_key: "123") }
 
+  describe "#initialize" do
+    context "when only required options are passed" do
+      it "initializes the client without any errors" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when llm_options are passed" do
+      let(:subject) { described_class.new(api_key: "123", llm_options: {uri_base: "http://localhost:1234"}) }
+
+      it "initializes the client without any errors" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "passes correct options to the client" do
+        # openai-ruby sets global configuration options here: https://github.com/alexrudall/ruby-openai/blob/main/lib/openai/client.rb
+        expect(OpenAI.configuration.uri_base).to eq("http://localhost:1234")
+      end
+    end
+  end
+
   describe "#embed" do
     before do
       allow(subject.client).to receive(:embeddings).and_return({


### PR DESCRIPTION
feat(openai.rb): add llm_options in OpenAI client initialization for …

docs(README.md): update documentation for new llm_options parameter

test(openai_spec.rb): add tests for new llm_options parameter in OpenAI client initialization