### PR TITLE
Add missing json require

### DIFF
--- a/lib/langchain/prompt/loading.rb
+++ b/lib/langchain/prompt/loading.rb
@@ -2,6 +2,7 @@
 
 require "strscan"
 require "pathname"
+require "json"
 
 module Langchain::Prompt
   TYPE_TO_LOADER = {


### PR DESCRIPTION
For this script:

```
#!/usr/bin/env ruby
require "langchain"

agent = Langchain::Agent::ChainOfThoughtAgent.new(llm: :openai, llm_api_key: ENV["OPENAI_API_KEY"], tools: ['calculator'])
puts agent.run(question: "What is the square root of 99?")
```

I was getting this error:

```
/Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/langchainrb-0.4.1/lib/langchain/prompt/loading.rb:26:in `load_from_path': uninitialized constant #<Class:Langchain::Prompt>::JSON (NameError)

        config = JSON.parse(File.read(file_path))
                 ^^^^
	from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/langchainrb-0.4.1/lib/langchain/agent/chain_of_thought_agent/chain_of_thought_agent.rb:101:in `prompt_template'
	from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/langchainrb-0.4.1/lib/langchain/agent/chain_of_thought_agent/chain_of_thought_agent.rb:88:in `create_prompt'
	from /Users/josh.nichols/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/langchainrb-0.4.1/lib/langchain/agent/chain_of_thought_agent/chain_of_thought_agent.rb:39:in `run'
	from main.rb:5:in `<main>'
```

It seems like just a case of missing require. I would guess it passes CI because one or more of the development dependencies already does a `require "json"`.