### PR TITLE
Split standardrb to its own CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -36,9 +35,18 @@ jobs:
           bundler: default
           bundler-cache: true
 
-      - name: StandardRb check
-        run: bundle exec standardrb
-
       - name: Run tests
         run: |
           bundle exec rspec 
+  linters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler: default
+          bundler-cache: true
+      - name: StandardRb check
+        run: bundle exec standardrb --format progress --format github --color


### PR DESCRIPTION
Currently, CI runs standardrb and then tests, so if standardb fails you don't get any feedback from the test.

It also runs standardb on all 3 versions of ruby. In practice, you really only need to run it on one version.

This splits `linters` out from `tests`. I tried to mirror the naming, but I'm open to explicitly calling it standardrb.

Lastly, I'm trying to turn on `--format github` which HOPEFULLY will start annotating the PR with the failure. We shouldn't have to rely on a maintainer to point out that standardrb --fix is needed :sweat_smile:

Oh, and since we are hear, also turn on color output since GitHub Actions supports it.