### PR TITLE
README says default log level is info, but is warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Additional examples available: [/examples](https://github.com/andreibondarev/lan
 
 ## Logging
 
-LangChain.rb uses standard logging mechanisms and defaults to `:debug` level. Most messages are at info level, but we will add debug or warn statements as needed.
+LangChain.rb uses standard logging mechanisms and defaults to `:warn` level. Most messages are at info level, but we will add debug or warn statements as needed.
 To show all log messages:
 
 ```ruby


### PR DESCRIPTION
https://github.com/andreibondarev/langchainrb/blob/dd8a1ffedd97ca07ebb3c7554748863776cbf016/lib/langchain.rb#L16