### PR TITLE
Add YARD for building documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,5 @@ jobs:
           ruby-version: 3.2
           bundler: default
           bundler-cache: true
-      - name: StandardRb check
+      - name: Build docs
         run: bundle exec rake yard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,15 @@ jobs:
           bundler-cache: true
       - name: StandardRb check
         run: bundle exec standardrb --format progress --format github --color
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler: default
+          bundler-cache: true
+      - name: StandardRb check
+        run: bundle exec rake yard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,7 @@ GEM
       graphlient (~> 0.6.0)
     wikipedia-client (1.17.0)
       addressable (~> 2.7)
+    yard (0.9.34)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -322,6 +323,7 @@ DEPENDENCIES
   standardrb
   weaviate-ruby (~> 0.8.0)
   wikipedia-client (~> 1.17.0)
+  yard
 
 BUNDLED WITH
    2.4.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     rb_sys (0.9.78)
+    rdiscount (2.2.7)
     regexp_parser (2.8.0)
     replicate-ruby (0.2.2)
       addressable
@@ -316,6 +317,7 @@ DEPENDENCIES
   pry-byebug (~> 3.10.0)
   qdrant-ruby (~> 0.9.0)
   rake (~> 13.0)
+  rdiscount
   replicate-ruby (~> 0.2.2)
   rspec (~> 3.0)
   ruby-openai (~> 4.0.0)

--- a/Rakefile
+++ b/Rakefile
@@ -14,4 +14,5 @@ Rake::Task["spec"].enhance do
 end
 
 YARD::Rake::YardocTask.new do |t|
+  t.options = ['--fail-on-warning']
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "standard/rake"
-require 'yard'
+require "yard"
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -14,5 +14,5 @@ Rake::Task["spec"].enhance do
 end
 
 YARD::Rake::YardocTask.new do |t|
-  t.options = ['--fail-on-warning']
+  t.options = ["--fail-on-warning"]
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "standard/rake"
+require 'yard'
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -10,4 +11,7 @@ task default: :spec
 
 Rake::Task["spec"].enhance do
   Rake::Task["standard:fix"].invoke
+end
+
+YARD::Rake::YardocTask.new do |t|
 end

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   # development dependencies
   spec.add_development_dependency "dotenv-rails", "~> 2.7.6"
   spec.add_development_dependency "pry-byebug", "~> 3.10.0"
+  spec.add_development_dependency "yard"
 
   # optional dependencies
   spec.add_development_dependency "chroma-db", "~> 0.3.0"

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv-rails", "~> 2.7.6"
   spec.add_development_dependency "pry-byebug", "~> 3.10.0"
   spec.add_development_dependency "yard"
+  spec.add_development_dependency "rdiscount" # for github-flavored markdown in yard
 
   # optional dependencies
   spec.add_development_dependency "chroma-db", "~> 0.3.0"

--- a/lib/langchain/prompt/base.rb
+++ b/lib/langchain/prompt/base.rb
@@ -64,9 +64,9 @@ module Langchain::Prompt
     #
     # This method takes a template string and returns an array of input variable names
     # contained within the template. Input variables are defined as text enclosed in
-    # curly braces (e.g. <code>{variable_name}</code>).
+    # curly braces (e.g. <code>\{variable_name\}</code>).
     #
-    # Content within two consecutive curly braces (e.g. <code>{{ignore_me}}</code>) are ignored.
+    # Content within two consecutive curly braces (e.g. <code>\{\{ignore_me}}</code>) are ignored.
     #
     # @param template [String] The template string to extract variables from.
     #

--- a/lib/langchain/prompt/base.rb
+++ b/lib/langchain/prompt/base.rb
@@ -64,9 +64,9 @@ module Langchain::Prompt
     #
     # This method takes a template string and returns an array of input variable names
     # contained within the template. Input variables are defined as text enclosed in
-    # curly braces (e.g. "{variable_name}").
+    # curly braces (e.g. <code>{variable_name}</code>).
     #
-    # Content within two consecutive curly braces (e.g. "{{ignore_me}}) are ignored.
+    # Content within two consecutive curly braces (e.g. <code>{{ignore_me}}</code>) are ignored.
     #
     # @param template [String] The template string to extract variables from.
     #

--- a/lib/langchain/prompt/prompt_template.rb
+++ b/lib/langchain/prompt/prompt_template.rb
@@ -20,7 +20,7 @@ module Langchain::Prompt
     end
 
     #
-    # Format the prompt with the inputs. Double {{}} replaced with single {} to adhere to f-string spec.
+    # Format the prompt with the inputs. Double <code>{{}}</code> replaced with single <code>{}</code> to adhere to f-string spec.
     #
     # @param kwargs [Hash] Any arguments to be passed to the prompt template.
     # @return [String] A formatted string.


### PR DESCRIPTION
Some work around https://github.com/andreibondarev/langchainrb/issues/54 for when we want to publish an API reference. I've confirmed this working locally, run with `bundle exec rake yard`, and then `open doc/index.html`

One thing I wasn't able to figure out was getting the emoji short codes in the table working. Regular emoji characters work though.

I did initially try to access on rubydoc.info, ie https://rubydoc.info/gems/langchainrb ... but something is definitely not right. Not sure if it's related to the repo, or something with that.

I can try again after this lands and is released to see if it helps. I can file an issue on https://github.com/docmeta/rubydoc.info if it still is around