### PR TITLE
Reduce max_tokens in SQLQueryAgent first step

### DIFF
--- a/lib/langchain/agent/sql_query_agent/sql_query_agent.rb
+++ b/lib/langchain/agent/sql_query_agent/sql_query_agent.rb
@@ -23,7 +23,7 @@ module Langchain::Agent
 
       # Get the SQL string to execute
       Langchain.logger.info("[#{self.class.name}]".red + ":  Passing the inital prompt to the #{llm.class} LLM")
-      sql_string = llm.complete(prompt: prompt, max_tokens: 500)
+      sql_string = llm.complete(prompt: prompt, max_tokens: 200)
 
       # Execute the SQL string and collect the results
       Langchain.logger.info("[#{self.class.name}]".red + ":  Passing the SQL to the Database: #{sql_string}")

--- a/spec/langchain/agent/sql_query_agent/sql_query_agent_spec.rb
+++ b/spec/langchain/agent/sql_query_agent/sql_query_agent_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Langchain::Agent::SQLQueryAgent do
     before do
       allow(subject.llm).to receive(:complete).with(
         prompt: original_prompt,
-        max_tokens: 500
+        max_tokens: 200
       ).and_return(llm_first_response)
 
       allow(Langchain::Tool::Database).to receive(:execute).with(


### PR DESCRIPTION
Prompt + completion was apparently sometimes exceeding the limit (see below).  200 should be good to return even a large sql_string.
Possible enhancement would be to calculate it:  model_limit - prompt_token_size.

```
max_tokens
integer
Optional
Defaults to 16
The maximum number of [tokens](https://platform.openai.com/tokenizer) to generate in the completion.

The token count of your prompt plus max_tokens cannot exceed the model's context length. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) for counting tokens.
```