### PR TITLE
Support rubocop tooling with standard rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+AllCops:
+  SuggestExtensions: false
+
+require:
+  - standard
+  - rubocop-performance
+
+inherit_gem:
+  standard: config/base.yml
+  standard-performance: config/base.yml
+  standard-custom: config/base.yml

--- a/bin/console
+++ b/bin/console
@@ -53,7 +53,7 @@ chroma = Langchain::Vectorsearch::Chroma.new(
   url: ENV["CHROMA_URL"],
   index_name: "documents",
   llm: :openai,
-  llm_api_key: ENV["OPENAI_API_KEY"],
+  llm_api_key: ENV["OPENAI_API_KEY"]
 )
 
 require "irb"


### PR DESCRIPTION
This way its possible to use rubocop cli, for example rubocop -A, and gets all of the standardrb rules applied. In my case some vscode extenstions doesnt know about standard, but works well with rubocop. Using this all just works and rubocop see the same rules.