### PR TITLE
Chat message history support for LLM:OpenAI

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -103,7 +103,7 @@ module Langchain::LLM
     end
 
     def validate_max_tokens(messages, model)
-      Langchain::Utils::TokenLengthValidator.validate_max_tokens!(messages.map { |m| m[:content] }, model)
+      Langchain::Utils::TokenLengthValidator.validate_max_tokens!(messages, model)
     end
   end
 end

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -65,7 +65,7 @@ module Langchain::LLM
     # @return [String] The chat completion
     #
     def chat(prompt: "", messages: [], **params)
-      return if prompt.empty? && messages.empty?
+      raise ArgumentError.new(":prompt or :messages argument is expected") if prompt.empty? && messages.empty?
 
       messages << {role: "user", content: prompt} if !prompt.empty?
 

--- a/lib/langchain/utils/token_length_validator.rb
+++ b/lib/langchain/utils/token_length_validator.rb
@@ -51,7 +51,7 @@ module Langchain
       #
       # Calculate the `max_tokens:` parameter to be set by calculating the context length of the text minus the prompt length
       #
-      # @param text [String] The text to validate
+      # @param content [String | Array<String>] The text or array of texts to validate
       # @param model_name [String] The model name to validate against
       # @return [Integer] Whether the text is valid or not
       # @raise [TokenLimitExceeded] If the text is too long

--- a/lib/langchain/utils/token_length_validator.rb
+++ b/lib/langchain/utils/token_length_validator.rb
@@ -57,7 +57,7 @@ module Langchain
       # @raise [TokenLimitExceeded] If the text is too long
       #
       def self.validate_max_tokens!(content, model_name)
-        text_token_length = Array(content).sum { |text| token_length(text, model_name) }
+        text_token_length = Array(content).sum { |item| token_length(item.to_json, model_name) }
 
         max_tokens = TOKEN_LIMITS[model_name] - text_token_length
 

--- a/lib/langchain/utils/token_length_validator.rb
+++ b/lib/langchain/utils/token_length_validator.rb
@@ -56,8 +56,9 @@ module Langchain
       # @return [Integer] Whether the text is valid or not
       # @raise [TokenLimitExceeded] If the text is too long
       #
-      def self.validate_max_tokens!(text, model_name)
-        text_token_length = token_length(text, model_name)
+      def self.validate_max_tokens!(content, model_name)
+        text_token_length = Array(content).sum { |text| token_length(text, model_name) }
+
         max_tokens = TOKEN_LIMITS[model_name] - text_token_length
 
         # Raise an error even if whole prompt is equal to the model's token limit (max_tokens == 0) since not response will be returned

--- a/lib/langchain/utils/token_length_validator.rb
+++ b/lib/langchain/utils/token_length_validator.rb
@@ -57,7 +57,11 @@ module Langchain
       # @raise [TokenLimitExceeded] If the text is too long
       #
       def self.validate_max_tokens!(content, model_name)
-        text_token_length = Array(content).sum { |item| token_length(item.to_json, model_name) }
+        text_token_length = if content.is_a?(Array)
+          content.sum { |item| token_length(item.to_json, model_name) }
+        else
+          token_length(content, model_name)
+        end
 
         max_tokens = TOKEN_LIMITS[model_name] - text_token_length
 

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe Langchain::LLM::OpenAI do
   end
 
   describe "#chat" do
+    let(:prompt) { "Hello! How are you?" }
     let(:response) do
       {
         "id" => "chatcmpl-7Hcl1sXOtsaUBKJGGhNujEIwhauaD",
@@ -153,8 +154,8 @@ RSpec.describe Langchain::LLM::OpenAI do
         {parameters: {messages: [{content: "Hello! How are you?", role: "user"}], model: "gpt-3.5-turbo", temperature: 0.0, max_tokens: 4090}}
       end
 
-      it "returns a chat message" do
-        expect(subject.chat(prompt: "Hello! How are you?")).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
+      it "sends prompt as message and returns a response message" do
+        expect(subject.chat(prompt: prompt)).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
       end
     end
 
@@ -163,8 +164,56 @@ RSpec.describe Langchain::LLM::OpenAI do
         {parameters: {messages: [{content: "Hello! How are you?", role: "user"}], model: "gpt-3.5-turbo-0301", temperature: 0.75, max_tokens: 4090}}
       end
 
-      it "returns a chat message" do
-        expect(subject.chat(prompt: "Hello! How are you?", model: "gpt-3.5-turbo-0301", temperature: 0.75)).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
+      it "sends prompt as message and additional params and returns a response message" do
+        expect(subject.chat(prompt: prompt, model: "gpt-3.5-turbo-0301", temperature: 0.75)).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
+      end
+    end
+
+    context "with message history" do
+      let(:parameters) do
+        {
+          parameters: {
+            messages: [
+              {role: "system", content: "You are a chatbot"},
+              {role: "user", content: "Hello"},
+              {role: "assistant", content: "Hi. How can I assist you today?"},
+              {role: "user", content: "How are you?"}
+            ],
+            model: "gpt-3.5-turbo",
+            temperature: 0.0,
+            max_tokens: 4077
+          }
+        }
+      end
+
+      context "with prompt and messages" do
+        let(:prompt) { "How are you?" }
+        let(:messages) do
+          [
+            {role: "system", content: "You are a chatbot"},
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi. How can I assist you today?"}
+          ]
+        end
+
+        it "combines prompt and messages and returns a response message" do
+          expect(subject.chat(prompt: prompt, messages: messages)).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
+        end
+      end
+
+      context "with messages" do
+        let(:messages) do
+          [
+            {role: "system", content: "You are a chatbot"},
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi. How can I assist you today?"},
+            {role: "user", content: "How are you?"}
+          ]
+        end
+
+        it "sends messages and returns a response message" do
+          expect(subject.chat(messages: messages)).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
+        end
       end
     end
   end

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with default parameters" do
       let(:parameters) do
-        {parameters: {model: "text-davinci-003", prompt: "Hello World", temperature: 0.0, max_tokens: 4093}}
+        {parameters: {model: "text-davinci-003", prompt: "Hello World", temperature: 0.0, max_tokens: 4095}}
       end
 
       it "returns a completion" do
@@ -104,7 +104,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with prompt and parameters" do
       let(:parameters) do
-        {parameters: {model: "text-curie-001", prompt: "Hello World", temperature: 1.0, max_tokens: 2045}}
+        {parameters: {model: "text-curie-001", prompt: "Hello World", temperature: 1.0, max_tokens: 2047}}
       end
 
       it "returns a completion" do

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with default parameters" do
       let(:parameters) do
-        {parameters: {model: "text-davinci-003", prompt: "Hello World", temperature: 0.0, max_tokens: 4095}}
+        {parameters: {model: "text-davinci-003", prompt: "Hello World", temperature: 0.0, max_tokens: 4093}}
       end
 
       it "returns a completion" do
@@ -104,7 +104,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with prompt and parameters" do
       let(:parameters) do
-        {parameters: {model: "text-curie-001", prompt: "Hello World", temperature: 1.0, max_tokens: 2047}}
+        {parameters: {model: "text-curie-001", prompt: "Hello World", temperature: 1.0, max_tokens: 2045}}
       end
 
       it "returns a completion" do
@@ -151,7 +151,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with default parameters" do
       let(:parameters) do
-        {parameters: {messages: [{content: "Hello! How are you?", role: "user"}], model: "gpt-3.5-turbo", temperature: 0.0, max_tokens: 4090}}
+        {parameters: {messages: [{content: "Hello! How are you?", role: "user"}], model: "gpt-3.5-turbo", temperature: 0.0, max_tokens: 4082}}
       end
 
       it "sends prompt as message and returns a response message" do
@@ -161,7 +161,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with prompt and parameters" do
       let(:parameters) do
-        {parameters: {messages: [{content: "Hello! How are you?", role: "user"}], model: "gpt-3.5-turbo-0301", temperature: 0.75, max_tokens: 4090}}
+        {parameters: {messages: [{content: "Hello! How are you?", role: "user"}], model: "gpt-3.5-turbo-0301", temperature: 0.75, max_tokens: 4082}}
       end
 
       it "sends prompt as message and additional params and returns a response message" do
@@ -181,7 +181,7 @@ RSpec.describe Langchain::LLM::OpenAI do
             ],
             model: "gpt-3.5-turbo",
             temperature: 0.0,
-            max_tokens: 4077
+            max_tokens: 4045
           }
         }
       end

--- a/spec/langchain/utils/token_length_validator_spec.rb
+++ b/spec/langchain/utils/token_length_validator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Langchain::Utils::TokenLengthValidator do
       end
     end
 
-    context 'with array argument' do
+    context "with array argument" do
       let(:content) { ["lorem ipsum" * 100, "lorem ipsum" * 100] }
       let(:model) { "gpt-4" }
 

--- a/spec/langchain/utils/token_length_validator_spec.rb
+++ b/spec/langchain/utils/token_length_validator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Langchain::Utils::TokenLengthValidator do
         it "raises an error" do
           expect {
             subject
-          }.to raise_error(Langchain::Utils::TokenLimitExceeded, "This model's maximum context length is 4097 tokens, but the given text is 45000 tokens long.")
+          }.to raise_error(Langchain::Utils::TokenLimitExceeded, "This model's maximum context length is 4097 tokens, but the given text is 45002 tokens long.")
         end
       end
 
@@ -25,7 +25,7 @@ RSpec.describe Langchain::Utils::TokenLengthValidator do
         end
 
         it "returns the correct max_tokens" do
-          expect(described_class.validate_max_tokens!("lorem ipsum" * 100, "gpt-4")).to eq(7892)
+          expect(described_class.validate_max_tokens!("lorem ipsum" * 100, "gpt-4")).to eq(7890)
         end
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe Langchain::Utils::TokenLengthValidator do
 
       context "when the text is not too long" do
         it "returns the correct max_tokens" do
-          expect(subject).to eq(7592)
+          expect(subject).to eq(7588)
         end
       end
     end

--- a/spec/langchain/utils/token_length_validator_spec.rb
+++ b/spec/langchain/utils/token_length_validator_spec.rb
@@ -2,19 +2,42 @@
 
 RSpec.describe Langchain::Utils::TokenLengthValidator do
   describe "#validate_max_tokens!" do
-    context "when the text is too long" do
-      it "raises an error" do
-        expect {
-          described_class.validate_max_tokens!("lorem ipsum" * 9000, "text-davinci-003")
-        }.to raise_error(Langchain::Utils::TokenLimitExceeded, "This model's maximum context length is 4097 tokens, but the given text is 45000 tokens long.")
+    subject { described_class.validate_max_tokens!(content, model) }
+
+    context "with text argument" do
+      context "when the text is too long" do
+        let(:content) { "lorem ipsum" * 9000 }
+        let(:model) { "text-davinci-003" }
+
+        it "raises an error" do
+          expect {
+            subject
+          }.to raise_error(Langchain::Utils::TokenLimitExceeded, "This model's maximum context length is 4097 tokens, but the given text is 45000 tokens long.")
+        end
+      end
+
+      context "when the text is not too long" do
+        let(:content) { "lorem ipsum" * 100 }
+        let(:model) { "gpt-4" }
+
+        it "does not raise an error" do
+          expect { subject }.not_to raise_error
+        end
+
+        it "returns the correct max_tokens" do
+          expect(described_class.validate_max_tokens!("lorem ipsum" * 100, "gpt-4")).to eq(7892)
+        end
       end
     end
 
-    context "when the text is not too long" do
-      it "does not raise an error" do
-        expect {
-          described_class.validate_max_tokens!("lorem ipsum" * 100, "gpt-4")
-        }.not_to raise_error
+    context 'with array argument' do
+      let(:content) { ["lorem ipsum" * 100, "lorem ipsum" * 100] }
+      let(:model) { "gpt-4" }
+
+      context "when the text is not too long" do
+        it "returns the correct max_tokens" do
+          expect(subject).to eq(7592)
+        end
       end
     end
   end

--- a/spec/langchain/utils/token_length_validator_spec.rb
+++ b/spec/langchain/utils/token_length_validator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Langchain::Utils::TokenLengthValidator do
         it "raises an error" do
           expect {
             subject
-          }.to raise_error(Langchain::Utils::TokenLimitExceeded, "This model's maximum context length is 4097 tokens, but the given text is 45002 tokens long.")
+          }.to raise_error(Langchain::Utils::TokenLimitExceeded, "This model's maximum context length is 4097 tokens, but the given text is 45000 tokens long.")
         end
       end
 
@@ -25,7 +25,7 @@ RSpec.describe Langchain::Utils::TokenLengthValidator do
         end
 
         it "returns the correct max_tokens" do
-          expect(described_class.validate_max_tokens!("lorem ipsum" * 100, "gpt-4")).to eq(7890)
+          expect(described_class.validate_max_tokens!("lorem ipsum" * 100, "gpt-4")).to eq(7892)
         end
       end
     end


### PR DESCRIPTION
## Changes
- Allow passing message history (as a simple array) to `chat` method of LLM::OpenAI. 
- Keep prompt argument for now, so that messages could be passed in several ways:

with no message history:
```ruby
client.chat(prompt: "How are you?")
```

with prompt and message history:
```ruby
client.chat(prompt: 'How are you?', messages: [{role: "system", content: "You are a chatbot"}])
```


with only message history:
```ruby
client.chat(messages: [{role: "system", content: "You are a chatbot"}, { role: "user", content: "How are you?"}])
```