### PR TITLE
Chat message history support for `Langchain::LLM::GooglePalm`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    google_palm_api (0.1.0)
+    google_palm_api (0.1.1)
       faraday (>= 1.0.0)
       faraday_middleware (>= 1.0.0)
     google_search_results (2.0.1)
@@ -310,7 +310,7 @@ DEPENDENCIES
   docx (~> 0.8.0)
   dotenv-rails (~> 2.7.6)
   eqn (~> 1.6.5)
-  google_palm_api (~> 0.1.0)
+  google_palm_api (~> 0.1.1)
   google_search_results (~> 2.0.0)
   hugging-face (~> 0.3.4)
   langchainrb!

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ replicate = Langchain::LLM::Replicate.new(api_key: ENV["REPLICATE_API_KEY"])
 ```
 
 #### Google PaLM (Pathways Language Model)
-Add `"google_palm_api", "~> 0.1.0"` to your Gemfile.
+Add `"google_palm_api", "~> 0.1.1"` to your Gemfile.
 ```ruby
 google_palm = Langchain::LLM::GooglePalm.new(api_key: ENV["GOOGLE_PALM_API_KEY"])
 ```

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cohere-ruby", "~> 0.9.4"
   spec.add_development_dependency "docx", "~> 0.8.0"
   spec.add_development_dependency "eqn", "~> 1.6.5"
-  spec.add_development_dependency "google_palm_api", "~> 0.1.0"
+  spec.add_development_dependency "google_palm_api", "~> 0.1.1"
   spec.add_development_dependency "google_search_results", "~> 2.0.0"
   spec.add_development_dependency "hugging-face", "~> 0.3.4"
   spec.add_development_dependency "milvus", "~> 0.9.0"

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -5,7 +5,7 @@ module Langchain::LLM
     #
     # Wrapper around the Google PaLM (Pathways Language Model) APIs.
     #
-    # Gem requirements: gem "google_palm_api", "~> 0.1.0"
+    # Gem requirements: gem "google_palm_api", "~> 0.1.1"
     #
     # Usage:
     # google_palm = Langchain::LLM::GooglePalm.new(api_key: "YOUR_API_KEY")
@@ -68,11 +68,15 @@ module Langchain::LLM
     # @param prompt [String] The prompt to generate a chat completion for
     # @return [String] The chat completion
     #
-    def chat(prompt:, **params)
+    def chat(prompt: "", messages: [], **params)
+      raise ArgumentError.new(":prompt or :messages argument is expected") if prompt.empty? && messages.empty?
+
+      messages << {author: "0", content: prompt} if !prompt.empty?
+
       # TODO: Figure out how to introduce persisted conversations
       default_params = {
-        prompt: prompt,
-        temperature: DEFAULTS[:temperature]
+        temperature: DEFAULTS[:temperature],
+        messages: messages
       }
 
       if params[:stop_sequences]

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -66,6 +66,7 @@ module Langchain::LLM
     # Generate a chat completion for a given prompt
     #
     # @param prompt [String] The prompt to generate a chat completion for
+    # @param messages [Array] The messages that have been sent in the conversation
     # @return [String] The chat completion
     #
     def chat(prompt: "", messages: [], **params)

--- a/spec/fixtures/llm/google_palm/chat_2.json
+++ b/spec/fixtures/llm/google_palm/chat_2.json
@@ -1,0 +1,22 @@
+{
+  "candidates": [
+    {
+      "author": "1",
+      "content": "I am currently working on a project to help people with their tasks. I am also learning more about the world and how to interact with people. I am excited to be able to help people and to learn more about the world.\r\n\r\nWhat are you up to today?"
+    }
+  ],
+  "messages": [
+    {
+      "author": "0",
+      "content": "Hey there! How are you?"
+    },
+    {
+      "author": "1",
+      "content": "I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?"
+    },
+    {
+      "author": "0",
+      "content": "I'm doing great. What are you up to?"
+    }
+  ]
+}

--- a/spec/langchain/llm/google_palm_spec.rb
+++ b/spec/langchain/llm/google_palm_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe Langchain::LLM::GooglePalm do
       it "returns a message" do
         expect(
           subject.chat(messages: [
-            { author: "0", content: completion },
-            { author: "1", content: "I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?" },
-            { author: "0", content: "I'm doing great. What are you up to?" }
+            {author: "0", content: completion},
+            {author: "1", content: "I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?"},
+            {author: "0", content: "I'm doing great. What are you up to?"}
           ])
         ).to eq("I am currently working on a project to help people with their tasks. I am also learning more about the world and how to interact with people. I am excited to be able to help people and to learn more about the world.\r\n\r\nWhat are you up to today?")
       end

--- a/spec/langchain/llm/google_palm_spec.rb
+++ b/spec/langchain/llm/google_palm_spec.rb
@@ -31,22 +31,45 @@ RSpec.describe Langchain::LLM::GooglePalm do
     end
 
     it "returns a completion" do
-      expect(subject.complete(prompt: "Hello world")).to eq("A man walks into a library and asks for books about paranoia. The librarian whispers, \"They're right behind you!\"")
+      expect(subject.complete(prompt: completion)).to eq("A man walks into a library and asks for books about paranoia. The librarian whispers, \"They're right behind you!\"")
     end
   end
 
   describe "#chat" do
     let(:completion) { "Hey there! How are you?" }
-    let(:fixture) { File.read("spec/fixtures/llm/google_palm/chat.json") }
 
-    before do
-      allow(subject.client).to receive(:generate_chat_message).and_return(
-        JSON.parse(fixture)
-      )
+    context "when prompt is passed in" do
+      let(:fixture) { File.read("spec/fixtures/llm/google_palm/chat.json") }
+
+      before do
+        allow(subject.client).to receive(:generate_chat_message).and_return(
+          JSON.parse(fixture)
+        )
+      end
+
+      it "returns a message" do
+        expect(subject.chat(prompt: completion)).to eq("I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?")
+      end
     end
 
-    it "returns a message" do
-      expect(subject.chat(prompt: "Hey there! How are you?")).to eq("I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?")
+    context "when messages are passed in" do
+      let(:fixture) { File.read("spec/fixtures/llm/google_palm/chat_2.json") }
+
+      before do
+        allow(subject.client).to receive(:generate_chat_message).and_return(
+          JSON.parse(fixture)
+        )
+      end
+
+      it "returns a message" do
+        expect(
+          subject.chat(messages: [
+            { author: "0", content: completion },
+            { author: "1", content: "I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?" },
+            { author: "0", content: "I'm doing great. What are you up to?" }
+          ])
+        ).to eq("I am currently working on a project to help people with their tasks. I am also learning more about the world and how to interact with people. I am excited to be able to help people and to learn more about the world.\r\n\r\nWhat are you up to today?")
+      end
     end
   end
 


### PR DESCRIPTION
## Changes
- Allow passing message history (as a simple array) to `chat` method of `Langchain::LLM::OpenAI`. 
- Keep prompt argument for now, so that messages could be passed in several ways:

with no message history:
```ruby
client.chat(prompt: "How are you?")
```

with prompt and message history:
```ruby
client.chat(prompt: 'How are you?', messages: [{author: "0", content: "You are a chatbot"}])
```

with only message history:
```ruby
palm.chat(messages: [
  { author: "0", content: "Hey there! How are you?" },
  { author: "1", content: "I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?" },
  { author: "0", content: "I'm doing great. What are you up to?" }
])
#=> "I am currently working on a project to help people with their tasks. I am also learning more about the world and how to interact with people. I am excited to be able to help people and to learn more about the world.\r\n\r\nWhat are you up to today?"```