### PR TITLE
Add basic Chat implementation

### DIFF
--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -62,6 +62,7 @@ module Langchain
 
   autoload :Loader, "langchain/loader"
   autoload :Data, "langchain/data"
+  autoload :Chat, "langchain/chat"
   autoload :DependencyHelper, "langchain/dependency_helper"
 
   module Agent

--- a/lib/langchain/chat.rb
+++ b/lib/langchain/chat.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Langchain
+  class Chat
+    attr_reader :context
+
+    def initialize(llm:, **options)
+      @llm = llm
+      @context = nil
+      @examples = []
+      @messages = []
+    end
+
+    # Set the context of the conversation. Usually used to set the model's persona.
+    # @param message [String] The context of the conversation
+    def set_context(message)
+      @context = message
+    end
+
+    # Add examples to the conversation. Used to give the model a sense of the conversation.
+    # @param examples [Array<Hash>] The examples to add to the conversation
+    def add_examples(examples)
+      @examples.concat examples
+    end
+
+    # Message the model with a prompt and return the response.
+    # @param message [String] The prompt to message the model with
+    # @return [String] The response from the model
+    def message(message)
+      build_history if @messages.empty?
+      append_user_message(message)
+      response = llm_response
+      append_ai_message(response)
+      response
+    end
+
+    private
+
+    def llm_response
+      @llm.chat(messages: @messages)
+    end
+
+    def build_history
+      set_system_message(@context) if !!@context
+      @messages.concat @examples
+    end
+
+    def append_ai_message(message)
+      @messages << {role: "assistant", content: message}
+    end
+
+    def append_user_message(message)
+      @messages << {role: "user", content: message}
+    end
+
+    def set_system_message(message)
+      @messages << {role: "system", content: message}
+    end
+  end
+end

--- a/spec/langchain/chat_spec.rb
+++ b/spec/langchain/chat_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe Langchain::Chat do
+  let(:llm) { double("Langchain::LLM::OpenaAI") }
+
+  subject { described_class.new(llm: llm) }
+
+  describe "#set_context" do
+    let(:context) { "You are a chatbot" }
+
+    it "sets the context" do
+      subject.set_context(context)
+
+      expect(subject.context).to eq(context)
+    end
+  end
+
+  describe "#add_examples" do
+    let(:examples1) { [{role: "user", content: "Hello"}, {role: "assistant", content: "Hi"}] }
+    let(:examples2) { [{role: "user", content: "How are you doing?"}, {role: "assistant", content: "I'm doing well. How about you?"}] }
+
+    it "adds examples" do
+      subject.add_examples(examples1)
+
+      expect(subject.instance_variable_get(:@examples)).to eq(examples1)
+
+      subject.add_examples(examples2)
+      expect(subject.instance_variable_get(:@examples)).to eq(examples1 | examples2)
+    end
+  end
+
+  describe "#message" do
+    let(:context) { "You are a chatbot" }
+    let(:examples) { [{role: "user", content: "Hello"}, {role: "assistant", content: "Hi"}] }
+    let(:prompt) { "How are you doing?" }
+    let(:response) { "I'm doing well. How about you?" }
+
+    context "with simple prompt" do
+      it "messages the model and returns the response" do
+        expect(llm).to receive(:chat).with(messages: [
+          {role: "user", content: prompt}
+        ]).and_return(response)
+
+        expect(subject.message(prompt)).to eq(response)
+      end
+    end
+
+    context "with context" do
+      before do
+        subject.set_context(context)
+      end
+
+      it "messages the model and returns the response" do
+        expect(llm).to receive(:chat).with(messages: [
+          {role: "system", content: context},
+          {role: "user", content: prompt}
+        ]).and_return(response)
+
+        expect(subject.message(prompt)).to eq(response)
+      end
+    end
+
+    context "with context and examples" do
+      before do
+        subject.set_context(context)
+        subject.add_examples(examples)
+      end
+
+      it "messages the model and returns the response" do
+        expect(llm).to receive(:chat).with(messages: [
+          {role: "system", content: context},
+          {role: "user", content: "Hello"},
+          {role: "assistant", content: "Hi"},
+          {role: "user", content: prompt}
+        ]).and_return(response)
+
+        expect(subject.message(prompt)).to eq(response)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation
An intuitive and unified API for creating chats with different LLMs.

## Example
```ruby
llm = Langchain::LLM::OpenAI.new api_key: ENV['OPEN_AI_KEY']
chat = Langchain::Chat.new llm: llm

chat.set_context "You are a travel assistant that only responds to travel questions. And responds ironically to other topics"

chat.message "What is most complex math problem?"
 => "Oh, I'm sorry, I thought you were looking for travel advice, not trying to give me a headache with math problems. But if you insist, the most complex math problem is probably the one that involves trying to calculate how much money you'll have left after booking a trip without checking your bank account first."

chat.message 'What is the second most visited place in Thailand?'
=> "Ah, a travel question! The second most visited place in Thailand after Bangkok is probably Phuket. It's a beautiful island with stunning beaches, great nightlife, and plenty of activities to keep you entertained. Just be prepared for the crowds of tourists and the occasional overpriced souvenir."
```

## Todo
- [ ] Keep general `Langchain::Chat` module with standardised `messages` format. Re-map messages to provider specific structure:
  - **OpenAi**: `{role: "assistant", content: "Some text..." }`
  - **Google PaLM2**: `{author: "ai", content: "Some text..."}`
- [ ] Allow to pass options and change them. Like changing `temperature`, `top_k` etc. 
- [ ] Calculate the number of tokens left after each message and truncate history as needed to keep conversation going instead of running into token limit exceeded.