### PR TITLE
use description from tool instance method

### DIFF
--- a/lib/langchain/agent/chain_of_thought_agent/chain_of_thought_agent.rb
+++ b/lib/langchain/agent/chain_of_thought_agent/chain_of_thought_agent.rb
@@ -101,7 +101,7 @@ module Langchain::Agent
         tool_names: "[#{tool_list.join(", ")}]",
         tools: tools.map do |tool|
           tool_name = tool.tool_name
-          tool_description = tool.class.const_get(:DESCRIPTION)
+          tool_description = tool.tool_description
           "#{tool_name}: #{tool_description}"
         end.join("\n")
       )

--- a/lib/langchain/tool/base.rb
+++ b/lib/langchain/tool/base.rb
@@ -58,6 +58,15 @@ module Langchain::Tool
     end
 
     #
+    # Returns the DESCRIPTION constant of the tool
+    #
+    # @return [String] tool description
+    #
+    def tool_description
+      self.class.const_get(:DESCRIPTION)
+    end
+
+    #
     # Sets the DESCRIPTION constant of the tool
     #
     # @param value [String] tool description


### PR DESCRIPTION
Takes `tool_description` from instance method, rather than directly from the class constant