### PR TITLE
Unified chat api for OpenAI and PaLM 

### DIFF
--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -94,6 +94,8 @@ module Langchain
 
   module Utils
     module TokenLength
+      class TokenLimitExceeded < StandardError; end
+
       autoload :OpenAIValidator, "langchain/utils/token_length/openai_validator"
       autoload :GooglePalmValidator, "langchain/utils/token_length/google_palm_validator"
     end

--- a/lib/langchain/chat.rb
+++ b/lib/langchain/chat.rb
@@ -27,34 +27,24 @@ module Langchain
     # @param message [String] The prompt to message the model with
     # @return [String] The response from the model
     def message(message)
-      build_history if @messages.empty?
       append_user_message(message)
-      response = llm_response
+      response = llm_response(message)
       append_ai_message(response)
       response
     end
 
     private
 
-    def llm_response
-      @llm.chat(messages: @messages)
-    end
-
-    def build_history
-      set_system_message(@context) if !!@context
-      @messages.concat @examples
+    def llm_response(prompt)
+      @llm.chat(messages: @messages, context: @context, examples: @examples)
     end
 
     def append_ai_message(message)
-      @messages << {role: "assistant", content: message}
+      @messages << {role: "ai", content: message}
     end
 
     def append_user_message(message)
       @messages << {role: "user", content: message}
-    end
-
-    def set_system_message(message)
-      @messages << {role: "system", content: message}
     end
   end
 end

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -147,8 +147,8 @@ module Langchain::LLM
     def compose_examples(examples)
       examples.each_slice(2).map do |example|
         {
-          input: { content: example.first[:content] },
-          output: { content: example.last[:content] },
+          input: {content: example.first[:content]},
+          output: {content: example.last[:content]}
         }
       end
     end

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -103,6 +103,8 @@ module Langchain::LLM
       default_params.merge!(options)
 
       response = client.generate_chat_message(**default_params)
+      raise "GooglePalm API returned an error: #{response}" if response.dig("error")
+
       response.dig("candidates", 0, "content")
     end
 
@@ -145,8 +147,8 @@ module Langchain::LLM
     def compose_examples(examples)
       examples.each_slice(2).map do |example|
         {
-          input: { content: example[0] },
-          output: { content: example[1] },
+          input: { content: example.first[:content] },
+          output: { content: example.last[:content] },
         }
       end
     end

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -138,7 +138,7 @@ module Langchain::LLM
         if history.last && history.last[:role] == "user"
           history.last[:content] += "\n#{prompt}"
         else
-          history.append({role: "user", content: prompt})
+          history.append({author: "user", content: prompt})
         end
       end
       history

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -90,7 +90,7 @@ module Langchain::LLM
         examples: compose_examples(examples)
       }
 
-      Langchain::Utils::TokenLength::GooglePalmValidator.validate_max_tokens!(self, messages, "chat-bison-001")
+      Langchain::Utils::TokenLength::GooglePalmValidator.validate_max_tokens!(self, default_params[:messages], "chat-bison-001")
 
       if options[:stop_sequences]
         default_params[:stop] = options.delete(:stop_sequences)

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -114,7 +114,7 @@ module Langchain::LLM
 
       history.concat transform_messages(messages) unless messages.empty?
 
-      unless context.empty?
+      unless context.nil? || context.empty?
         history.reject! { |message| message[:role] == "system" }
         history.prepend({role: "system", content: context})
       end

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -63,19 +63,22 @@ module Langchain::LLM
     #
     # @param prompt [String] The prompt to generate a chat completion for
     # @param messages [Array] The messages that have been sent in the conversation
-    # @param params extra parameters passed to OpenAI::Client#chat
+    # @param context [String] The context of the conversation
+    # @param examples [Array] Examples of messages provide model with
+    # @param options extra parameters passed to OpenAI::Client#chat
     # @return [String] The chat completion
     #
-    def chat(prompt: "", messages: [], **params)
+    def chat(prompt: "", messages: [], context: "", examples: [], **options)
       raise ArgumentError.new(":prompt or :messages argument is expected") if prompt.empty? && messages.empty?
 
-      messages << {role: "user", content: prompt} if !prompt.empty?
-
-      parameters = compose_parameters DEFAULTS[:chat_completion_model_name], params
-      parameters[:messages] = messages
-      parameters[:max_tokens] = validate_max_tokens(messages, parameters[:model])
+      parameters = compose_parameters DEFAULTS[:chat_completion_model_name], options
+      parameters[:messages] = compose_chat_messages(prompt: prompt, messages: messages, context: context, examples: examples)
+      parameters[:max_tokens] = validate_max_tokens(parameters[:messages], parameters[:model])
 
       response = client.chat(parameters: parameters)
+
+      raise "Chat completion failed: #{response}" if response.dig("error")
+
       response.dig("choices", 0, "message", "content")
     end
 
@@ -102,6 +105,38 @@ module Langchain::LLM
       default_params[:stop] = params.delete(:stop_sequences) if params[:stop_sequences]
 
       default_params.merge(params)
+    end
+
+    def compose_chat_messages(prompt:, messages:, context:, examples:)
+      history = []
+
+      history.concat transform_messages(examples) unless examples.empty?
+
+      history.concat transform_messages(messages) unless messages.empty?
+
+      unless context.empty?
+        history.reject! { |message| message[:role] == "system" }
+        history.prepend({role: "system", content: context})
+      end
+
+      unless prompt.empty?
+        if history.last && history.last[:role] == "user"
+          history.last[:content] += "\n#{prompt}"
+        else
+          history.append({role: "user", content: prompt})
+        end
+      end
+
+      history
+    end
+
+    def transform_messages(messages)
+      messages.map do |message|
+        {
+          content: message[:content],
+          role: (message[:role] == "ai") ? "assistant" : message[:role]
+        }
+      end
     end
 
     def validate_max_tokens(messages, model)

--- a/lib/langchain/utils/token_length/google_palm_validator.rb
+++ b/lib/langchain/utils/token_length/google_palm_validator.rb
@@ -3,8 +3,6 @@
 module Langchain
   module Utils
     module TokenLength
-      class TokenLimitExceeded < StandardError; end
-
       #
       # This class is meant to validate the length of the text passed in to Google Palm's API.
       # It is used to validate the token length before the API call is made

--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -5,8 +5,6 @@ require "tiktoken_ruby"
 module Langchain
   module Utils
     module TokenLength
-      class TokenLimitExceeded < StandardError; end
-
       #
       # This class is meant to validate the length of the text passed in to OpenAI's API.
       # It is used to validate the token length before the API call is made

--- a/spec/langchain/chat_spec.rb
+++ b/spec/langchain/chat_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Langchain::Chat do
   end
 
   describe "#add_examples" do
-    let(:examples1) { [{role: "user", content: "Hello"}, {role: "assistant", content: "Hi"}] }
-    let(:examples2) { [{role: "user", content: "How are you doing?"}, {role: "assistant", content: "I'm doing well. How about you?"}] }
+    let(:examples1) { [{role: "user", content: "Hello"}, {role: "ai", content: "Hi"}] }
+    let(:examples2) { [{role: "user", content: "How are you doing?"}, {role: "ai", content: "I'm doing well. How about you?"}] }
 
     it "adds examples" do
       subject.add_examples(examples1)
@@ -31,15 +31,17 @@ RSpec.describe Langchain::Chat do
 
   describe "#message" do
     let(:context) { "You are a chatbot" }
-    let(:examples) { [{role: "user", content: "Hello"}, {role: "assistant", content: "Hi"}] }
+    let(:examples) { [{role: "user", content: "Hello"}, {role: "ai", content: "Hi"}] }
     let(:prompt) { "How are you doing?" }
     let(:response) { "I'm doing well. How about you?" }
 
     context "with simple prompt" do
       it "messages the model and returns the response" do
-        expect(llm).to receive(:chat).with(messages: [
-          {role: "user", content: prompt}
-        ]).and_return(response)
+        expect(llm).to receive(:chat).with(
+          context: nil,
+          examples: [],
+          messages: [{role: "user", content: prompt}]
+        ).and_return(response)
 
         expect(subject.message(prompt)).to eq(response)
       end
@@ -51,10 +53,11 @@ RSpec.describe Langchain::Chat do
       end
 
       it "messages the model and returns the response" do
-        expect(llm).to receive(:chat).with(messages: [
-          {role: "system", content: context},
-          {role: "user", content: prompt}
-        ]).and_return(response)
+        expect(llm).to receive(:chat).with(
+          context: context,
+          examples: [],
+          messages: [{role: "user", content: prompt}]
+        ).and_return(response)
 
         expect(subject.message(prompt)).to eq(response)
       end
@@ -67,12 +70,16 @@ RSpec.describe Langchain::Chat do
       end
 
       it "messages the model and returns the response" do
-        expect(llm).to receive(:chat).with(messages: [
-          {role: "system", content: context},
-          {role: "user", content: "Hello"},
-          {role: "assistant", content: "Hi"},
-          {role: "user", content: prompt}
-        ]).and_return(response)
+        expect(llm).to receive(:chat).with(
+          context: context,
+          examples: [
+            {role: "user", content: "Hello"},
+            {role: "ai", content: "Hi"}
+          ],
+          messages: [
+            {role: "user", content: prompt}
+          ]
+        ).and_return(response)
 
         expect(subject.message(prompt)).to eq(response)
       end


### PR DESCRIPTION
### Motivation
Make `Langchain::Chat` work with OpenAI and PaLM models. 

### Changes
- Update `Langchain::LLM::OpenAI` and `Langchain::LLM::GooglePalm`'s `chat` method to accept `prompt`, `messages`, `context` and `examples` arguments.
- Make LLM classes responsible for converting generic message format to format accepted by the corresponding API
- Update  `Langchain::Chat` to pass arguments in generic format to `chat` method on LLM class
