### PR TITLE
Rename Langchain::Chat to Langchain::Conversation

### DIFF
--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -62,7 +62,7 @@ module Langchain
 
   autoload :Loader, "langchain/loader"
   autoload :Data, "langchain/data"
-  autoload :Chat, "langchain/chat"
+  autoload :Conversation, "langchain/conversation"
   autoload :DependencyHelper, "langchain/dependency_helper"
 
   module Agent

--- a/lib/langchain/conversation.rb
+++ b/lib/langchain/conversation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Langchain
-  class Chat
+  class Conversation
     attr_reader :context
 
     def initialize(llm:, **options)

--- a/spec/langchain/conversation_spec.rb
+++ b/spec/langchain/conversation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Langchain::Chat do
+RSpec.describe Langchain::Conversation do
   let(:llm) { double("Langchain::LLM::OpenaAI") }
 
   subject { described_class.new(llm: llm) }


### PR DESCRIPTION
### Changes
Renaming of a newly introduced API: `Chat` => `Conversation`. I like the meaning of "conversation" more. However, it is a longer name and more characters to type. 

Let's vote for this renaming 👍  or 👎 