### PR TITLE
Conversation options

### DIFF
--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -62,7 +62,7 @@ module Langchain
 
   autoload :Loader, "langchain/loader"
   autoload :Data, "langchain/data"
-  autoload :Chat, "langchain/chat"
+  autoload :Conversation, "langchain/conversation"
   autoload :DependencyHelper, "langchain/dependency_helper"
 
   module Agent

--- a/lib/langchain/conversation.rb
+++ b/lib/langchain/conversation.rb
@@ -1,11 +1,27 @@
 # frozen_string_literal: true
 
 module Langchain
+  #
+  # A high-level API for running a conversation with an LLM.
+  # Currently supports: OpenAI and Google PaLM LLMs.
+  #
+  # Usage:
+  #     llm = Langchain::LLM::OpenAI.new(api_key: "YOUR_API_KEY")
+  #     chat = Langchain::Conversation.new(llm: llm)
+  #     chat.set_context("You are a chatbot from the future")
+  #     chat.message("Tell me about future technologies")
+  #
   class Conversation
-    attr_reader :context
+    attr_reader :context, :examples
 
+    # Intialize Conversation with a LLM
+    #
+    # @param llm [Object] The LLM to use for the conversation
+    # @param options [Hash] Options to pass to the LLM, like temperature, top_k, etc.
+    # @return [Langchain::Conversation] The Langchain::Conversation instance
     def initialize(llm:, **options)
       @llm = llm
+      @options = options
       @context = nil
       @examples = []
       @messages = []
@@ -36,7 +52,7 @@ module Langchain
     private
 
     def llm_response(prompt)
-      @llm.chat(messages: @messages, context: @context, examples: @examples)
+      @llm.chat(messages: @messages, context: @context, examples: @examples, **@options)
     end
 
     def append_ai_message(message)

--- a/lib/langchain/conversation.rb
+++ b/lib/langchain/conversation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Langchain
-  class Chat
+  class Conversation
     attr_reader :context
 
     def initialize(llm:, **options)

--- a/spec/langchain/conversation_spec.rb
+++ b/spec/langchain/conversation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Langchain::Chat do
+RSpec.describe Langchain::Conversation do
   let(:llm) { double("Langchain::LLM::OpenaAI") }
 
   subject { described_class.new(llm: llm) }

--- a/spec/langchain/conversation_spec.rb
+++ b/spec/langchain/conversation_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Langchain::Conversation do
       subject { described_class.new(llm: llm, temperature: 0.7) }
 
       it "messages the model with passed options" do
-         expect(llm).to receive(:chat).with(
+        expect(llm).to receive(:chat).with(
           context: nil,
           examples: [],
           messages: [{role: "user", content: prompt}],

--- a/spec/langchain/conversation_spec.rb
+++ b/spec/langchain/conversation_spec.rb
@@ -84,5 +84,20 @@ RSpec.describe Langchain::Conversation do
         expect(subject.message(prompt)).to eq(response)
       end
     end
+
+    context "with options" do
+      subject { described_class.new(llm: llm, temperature: 0.7) }
+
+      it "messages the model with passed options" do
+         expect(llm).to receive(:chat).with(
+          context: nil,
+          examples: [],
+          messages: [{role: "user", content: prompt}],
+          temperature: 0.7
+        ).and_return(response)
+
+        expect(subject.message(prompt)).to eq(response)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Changes
- Allow passing options to LLM through Conversation initializer
- Add annotations to `Langchain::Conversation` class