### PR TITLE
Add attr_reader for conversation messages

### DIFF
--- a/lib/langchain/conversation.rb
+++ b/lib/langchain/conversation.rb
@@ -12,7 +12,7 @@ module Langchain
   #     chat.message("Tell me about future technologies")
   #
   class Conversation
-    attr_reader :context, :examples
+    attr_reader :context, :examples, :messages
 
     # Intialize Conversation with a LLM
     #


### PR DESCRIPTION
This pull request adds an attr_reader for the @message instance variable. This allows for easy access to the message history and enables users to save it if needed.