### PR TITLE
Allow passing default options when instantiating the llm

### DIFF
--- a/lib/langchain/llm/ai21.rb
+++ b/lib/langchain/llm/ai21.rb
@@ -32,7 +32,7 @@ module Langchain::LLM
     # @return [String] The completion
     #
     def complete(prompt:, **params)
-      parameters = complete_parameters @defaults[:model], params
+      parameters = complete_parameters params
 
       response = client.complete(prompt, parameters)
       response.dig(:completions, 0, :data, :text)
@@ -52,10 +52,8 @@ module Langchain::LLM
 
     private
 
-    def complete_parameters(model, params)
-      default_params = {model: model, temperature: @defaults[:temperature]}
-
-      default_params.merge(params)
+    def complete_parameters(params)
+      @defaults.dup.merge(params)
     end
   end
 end

--- a/lib/langchain/llm/cohere.rb
+++ b/lib/langchain/llm/cohere.rb
@@ -18,11 +18,12 @@ module Langchain::LLM
       dimension: 1024
     }.freeze
 
-    def initialize(api_key:)
+    def initialize(api_key:, default_options: {})
       depends_on "cohere-ruby"
       require "cohere"
 
       @client = ::Cohere::Client.new(api_key: api_key)
+      @defaults = DEFAULTS.merge(default_options)
     end
 
     #
@@ -34,7 +35,7 @@ module Langchain::LLM
     def embed(text:)
       response = client.embed(
         texts: [text],
-        model: DEFAULTS[:embeddings_model_name]
+        model: @defaults[:embeddings_model_name]
       )
       response.dig("embeddings").first
     end
@@ -49,8 +50,8 @@ module Langchain::LLM
     def complete(prompt:, **params)
       default_params = {
         prompt: prompt,
-        temperature: DEFAULTS[:temperature],
-        model: DEFAULTS[:completion_model_name]
+        temperature: @defaults[:temperature],
+        model: @defaults[:completion_model_name]
       }
 
       if params[:stop_sequences]

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -91,12 +91,13 @@ module Langchain::LLM
 
       default_params = {
         temperature: @defaults[:temperature],
-        completion_model_name: @defaults[:completion_model_name],
+        chat_completion_model_name: @defaults[:chat_completion_model_name],
         context: context,
         messages: compose_chat_messages(prompt: prompt, messages: messages),
         examples: compose_examples(examples)
       }
 
+      # chat-bison-001 is the only model that currently supports countMessageTokens functions
       LENGTH_VALIDATOR.validate_max_tokens!(default_params[:messages], "chat-bison-001", llm: self)
 
       if options[:stop_sequences]

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -18,11 +18,12 @@ module Langchain::LLM
       dimension: 1536
     }.freeze
 
-    def initialize(api_key:, llm_options: {})
+    def initialize(api_key:, llm_options: {}, default_options: {})
       depends_on "ruby-openai"
       require "openai"
 
       @client = ::OpenAI::Client.new(access_token: api_key, **llm_options)
+      @defaults = DEFAULTS.merge(default_options)
     end
 
     #
@@ -33,7 +34,7 @@ module Langchain::LLM
     # @return [Array] The embedding
     #
     def embed(text:, **params)
-      parameters = {model: DEFAULTS[:embeddings_model_name], input: text}
+      parameters = {model: @defaults[:embeddings_model_name], input: text}
 
       Langchain::Utils::TokenLength::OpenAIValidator.validate_max_tokens!(text, parameters[:model])
 
@@ -49,7 +50,7 @@ module Langchain::LLM
     # @return [String] The completion
     #
     def complete(prompt:, **params)
-      parameters = compose_parameters DEFAULTS[:completion_model_name], params
+      parameters = compose_parameters @defaults[:completion_model_name], params
 
       parameters[:prompt] = prompt
       parameters[:max_tokens] = Langchain::Utils::TokenLength::OpenAIValidator.validate_max_tokens!(prompt, parameters[:model])
@@ -72,7 +73,7 @@ module Langchain::LLM
     def chat(prompt: "", messages: [], context: "", examples: [], **options)
       raise ArgumentError.new(":prompt or :messages argument is expected") if prompt.empty? && messages.empty?
 
-      parameters = compose_parameters DEFAULTS[:chat_completion_model_name], options
+      parameters = compose_parameters @defaults[:chat_completion_model_name], options
       parameters[:messages] = compose_chat_messages(prompt: prompt, messages: messages, context: context, examples: examples)
       parameters[:max_tokens] = validate_max_tokens(parameters[:messages], parameters[:model])
 
@@ -103,13 +104,13 @@ module Langchain::LLM
       )
       prompt = prompt_template.format(text: text)
 
-      complete(prompt: prompt, temperature: DEFAULTS[:temperature])
+      complete(prompt: prompt, temperature: @defaults[:temperature])
     end
 
     private
 
     def compose_parameters(model, params)
-      default_params = {model: model, temperature: DEFAULTS[:temperature]}
+      default_params = {model: model, temperature: @defaults[:temperature]}
 
       default_params[:stop] = params.delete(:stop_sequences) if params[:stop_sequences]
 

--- a/lib/langchain/llm/replicate.rb
+++ b/lib/langchain/llm/replicate.rb
@@ -32,7 +32,7 @@ module Langchain::LLM
     #
     # @param api_key [String] The API key to use
     #
-    def initialize(api_key:)
+    def initialize(api_key:, default_options: {})
       depends_on "replicate-ruby"
       require "replicate"
 
@@ -41,6 +41,7 @@ module Langchain::LLM
       end
 
       @client = ::Replicate.client
+      @defaults = DEFAULTS.merge(default_options)
     end
 
     #
@@ -100,7 +101,7 @@ module Langchain::LLM
 
       complete(
         prompt: prompt,
-        temperature: DEFAULTS[:temperature],
+        temperature: @defaults[:temperature],
         # Most models have a context length of 2048 tokens (except for the newest models, which support 4096).
         max_tokens: 2048
       )
@@ -111,11 +112,11 @@ module Langchain::LLM
     private
 
     def completion_model
-      @completion_model ||= client.retrieve_model(DEFAULTS[:completion_model_name]).latest_version
+      @completion_model ||= client.retrieve_model(@defaults[:completion_model_name]).latest_version
     end
 
     def embeddings_model
-      @embeddings_model ||= client.retrieve_model(DEFAULTS[:embeddings_model_name]).latest_version
+      @embeddings_model ||= client.retrieve_model(@defaults[:embeddings_model_name]).latest_version
     end
   end
 end

--- a/spec/langchain/conversation_spec.rb
+++ b/spec/langchain/conversation_spec.rb
@@ -233,7 +233,8 @@ RSpec.describe Langchain::Conversation do
                 {author: "ai", content: messages[3][:content]},
                 {author: "user", content: prompt}
               ],
-              temperature: 0.0
+              temperature: 0.0,
+              chat_completion_model_name: "chat-bison-001"
             ).and_return(response)
 
             expect(subject.message(prompt)).to eq("I'm doing well. How about you?")

--- a/spec/langchain/llm/ai21_spec.rb
+++ b/spec/langchain/llm/ai21_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Langchain::LLM::AI21 do
 
     context "with no additional parameters" do
       before do
-        allow(subject.client).to receive(:complete).with("Hello World", {}).and_return(response)
+        allow(subject.client).to receive(:complete)
+          .with("Hello World", {model: "j2-large", temperature: 0.0})
+          .and_return(response)
       end
 
       it "returns a completion" do
@@ -41,6 +43,27 @@ RSpec.describe Langchain::LLM::AI21 do
         expect(subject.complete(prompt: "Hello World", model: "j2-jumbo", temperature: 0.7)).to eq(
           "\nWhat is the meaning of life? What is the meaning of life?\nWhat is the meaning"
         )
+      end
+    end
+
+    context "with custom default_options" do
+      let(:subject) {
+        described_class.new(
+          api_key: "123",
+          default_options: {model: "j2-mid"}
+        )
+      }
+
+      it "passes correct options to the client's complete method" do
+        expect(subject.client).to receive(:complete).with(
+          "Hello World",
+          {
+            model: "j2-mid",
+            temperature: 0.0
+          }
+        ).and_return(response)
+
+        subject.complete(prompt: "Hello World")
       end
     end
   end

--- a/spec/langchain/llm/cohere_spec.rb
+++ b/spec/langchain/llm/cohere_spec.rb
@@ -41,6 +41,26 @@ RSpec.describe Langchain::LLM::Cohere do
     it "returns a completion" do
       expect(subject.complete(prompt: "Hello World")).to eq("\nWhat is the meaning of life? What is the meaning of life?\nWhat is the meaning")
     end
+
+    context "with custom default_options" do
+      let(:subject) {
+        described_class.new(
+          api_key: "123",
+          default_options: {completion_model_name: "base-light"}
+        )
+      }
+
+      it "passes correct options to the completions method" do
+        expect(subject.client).to receive(:generate).with(
+          {
+            model: "base-light",
+            prompt: "Hello World",
+            temperature: 0.0
+          }
+        )
+        subject.complete(prompt: "Hello World")
+      end
+    end
   end
 
   describe "#default_dimension" do

--- a/spec/langchain/llm/google_palm_spec.rb
+++ b/spec/langchain/llm/google_palm_spec.rb
@@ -99,14 +99,14 @@ RSpec.describe Langchain::LLM::GooglePalm do
         let(:subject) {
           described_class.new(
             api_key: "123",
-            default_options: {completion_model_name: "chat-bison-foo"}
+            default_options: {chat_completion_model_name: "chat-bison-foo"}
           )
         }
 
         it "passes correct options to the completions method" do
           expect(subject.client).to receive(:generate_chat_message).with(
             {
-              completion_model_name: "chat-bison-foo",
+              chat_completion_model_name: "chat-bison-foo",
               context: "",
               examples: [],
               messages: [{author: "user", content: "Hey there! How are you?"}],

--- a/spec/langchain/llm/google_palm_spec.rb
+++ b/spec/langchain/llm/google_palm_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe Langchain::LLM::GooglePalm do
     it "returns a completion" do
       expect(subject.complete(prompt: completion)).to eq("A man walks into a library and asks for books about paranoia. The librarian whispers, \"They're right behind you!\"")
     end
+
+    context "with custom default_options" do
+      let(:subject) {
+        described_class.new(
+          api_key: "123",
+          default_options: {completion_model_name: "text-bison-foo"}
+        )
+      }
+
+      it "passes correct options to the completions method" do
+        expect(subject.client).to receive(:generate_text).with(
+          {
+            completion_model_name: "text-bison-foo",
+            prompt: "Hello World",
+            temperature: 0.0
+          }
+        ).and_return(response)
+        subject.complete(prompt: "Hello World")
+      end
+    end
   end
 
   describe "#chat" do
@@ -73,6 +93,28 @@ RSpec.describe Langchain::LLM::GooglePalm do
 
       it "returns a message" do
         expect(subject.chat(prompt: completion)).to eq("I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?")
+      end
+
+      context "with custom default_options" do
+        let(:subject) {
+          described_class.new(
+            api_key: "123",
+            default_options: {completion_model_name: "chat-bison-foo"}
+          )
+        }
+
+        it "passes correct options to the completions method" do
+          expect(subject.client).to receive(:generate_chat_message).with(
+            {
+              completion_model_name: "chat-bison-foo",
+              context: "",
+              examples: [],
+              messages: [{author: "user", content: "Hey there! How are you?"}],
+              temperature: 0.0
+            }
+          )
+          subject.chat(prompt: completion)
+        end
       end
     end
 

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -102,6 +102,33 @@ RSpec.describe Langchain::LLM::OpenAI do
       end
     end
 
+    context "with custom default_options" do
+      let(:subject) {
+        described_class.new(
+          api_key: "123",
+          default_options: {completion_model_name: "gpt-3.5-turbo-16k"}
+        )
+      }
+
+      let(:parameters) do
+        {parameters:
+          {model: "text-davinci-003",
+           prompt: "Hello World",
+           temperature: 0.0,
+           max_tokens: 4095}}
+      end
+
+      it "passes correct options to the completions method" do
+        expect(subject.client).to receive(:completions).with(
+          {parameters: {max_tokens: 16382,
+                        model: "gpt-3.5-turbo-16k",
+                        prompt: "Hello World",
+                        temperature: 0.0}}
+        ).and_return(response)
+        subject.complete(prompt: "Hello World")
+      end
+    end
+
     context "with prompt and parameters" do
       let(:parameters) do
         {parameters: {model: "text-curie-001", prompt: "Hello World", temperature: 1.0, max_tokens: 2047}}

--- a/spec/langchain/llm/replicate_spec.rb
+++ b/spec/langchain/llm/replicate_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe Langchain::LLM::Replicate do
     it "returns an embedding" do
       expect(subject.complete(prompt: prompt)).to eq("Foo bar !")
     end
+
+    context "with custom default_options" do
+      let(:subject) {
+        described_class.new(
+          api_key: "123",
+          default_options: {completion_model_name: "replicate/vicuna-foobar"}
+        )
+      }
+
+      it "passes correct options to the completions method" do
+        latest_version_stub = double("latest_version")
+        expect(latest_version_stub).to receive(:latest_version).and_return(model)
+
+        expect(subject.client).to receive(:retrieve_model).with(
+          "replicate/vicuna-foobar"
+        ).and_return(latest_version_stub)
+
+        subject.complete(prompt: "Hello World")
+      end
+    end
   end
 
   describe "#embed" do


### PR DESCRIPTION
This makes it possible to set the LLM model when instantiating the class, rather than just when running the completion method (e.g. `complete`). Helpful when running an Agent and you want it to use a particular model. 