### PR TITLE
add max token length validator for Cohere; add `truncate` to default_options

### DIFF
--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -106,6 +106,7 @@ module Langchain
 
       autoload :OpenAIValidator, "langchain/utils/token_length/openai_validator"
       autoload :GooglePalmValidator, "langchain/utils/token_length/google_palm_validator"
+      autoload :CohereValidator, "langchain/utils/token_length/cohere_validator"
     end
   end
 

--- a/lib/langchain/llm/cohere.rb
+++ b/lib/langchain/llm/cohere.rb
@@ -50,7 +50,8 @@ module Langchain::LLM
       default_params = {
         prompt: prompt,
         temperature: DEFAULTS[:temperature],
-        model: DEFAULTS[:completion_model_name]
+        model: DEFAULTS[:completion_model_name],
+        truncate: "START"
       }
 
       if params[:stop_sequences]
@@ -58,6 +59,8 @@ module Langchain::LLM
       end
 
       default_params.merge!(params)
+
+      default_params[:max_tokens] = Langchain::Utils::TokenLength::CohereValidator.validate_max_tokens!(prompt, default_params[:model], client)
 
       response = client.generate(**default_params)
       response.dig("generations").first.dig("text")

--- a/lib/langchain/llm/cohere.rb
+++ b/lib/langchain/llm/cohere.rb
@@ -15,7 +15,8 @@ module Langchain::LLM
       temperature: 0.0,
       completion_model_name: "base",
       embeddings_model_name: "small",
-      dimension: 1024
+      dimension: 1024,
+      truncate: "START"
     }.freeze
 
     def initialize(api_key:, default_options: {})
@@ -51,7 +52,8 @@ module Langchain::LLM
       default_params = {
         prompt: prompt,
         temperature: @defaults[:temperature],
-        model: @defaults[:completion_model_name]
+        model: @defaults[:completion_model_name],
+        truncate: @defaults[:truncate]
       }
 
       if params[:stop_sequences]

--- a/lib/langchain/utils/token_length/cohere_validator.rb
+++ b/lib/langchain/utils/token_length/cohere_validator.rb
@@ -8,7 +8,7 @@ module Langchain
       # It is used to validate the token length before the API call is made
       #
 
-      class CohereValidator
+      class CohereValidator < BaseValidator
         TOKEN_LIMITS = {
           # Source:
           # https://docs.cohere.com/docs/models
@@ -22,30 +22,6 @@ module Langchain
           "summarize-medium" => 2048,
           "summarize-xlarge" => 2048
         }.freeze
-        #
-        # Calculate the `max_tokens:` parameter to be set by calculating the context length of the text minus the prompt length
-        #
-        # @param content [String | Array<String>] The text or array of texts to validate
-        # @param model_name [String] The model name to validate against
-        # @return [Integer] Whether the text is valid or not
-        # @raise [TokenLimitExceeded] If the text is too long
-        #
-        def self.validate_max_tokens!(content, model_name, client)
-          text_token_length = if content.is_a?(Array)
-            content.sum { |item| token_length(item.to_json, model_name, client) }
-          else
-            token_length(content, model_name, client)
-          end
-
-          max_tokens = TOKEN_LIMITS[model_name] - text_token_length
-
-          # Raise an error even if whole prompt is equal to the model's token limit (max_tokens == 0) since not response will be returned
-          if max_tokens <= 0
-            raise TokenLimitExceeded, "This model's maximum context length is #{TOKEN_LIMITS[model_name]} tokens, but the given text is #{text_token_length} tokens long."
-          end
-
-          max_tokens
-        end
 
         #
         # Calculate token length for a given text and model name
@@ -57,6 +33,10 @@ module Langchain
         def self.token_length(text, model_name, client)
           res = client.tokenize(text: text)
           res["tokens"].length
+        end
+
+        def self.token_limit(model_name)
+          TOKEN_LIMITS[model_name]
         end
       end
     end

--- a/lib/langchain/utils/token_length/cohere_validator.rb
+++ b/lib/langchain/utils/token_length/cohere_validator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Langchain
+  module Utils
+    module TokenLength
+      #
+      # This class is meant to validate the length of the text passed in to Cohere's API.
+      # It is used to validate the token length before the API call is made
+      #
+
+      class CohereValidator
+        TOKEN_LIMITS = {
+          # Source:
+          # https://docs.cohere.com/docs/models
+          "command-light" => 4096,
+          "command" => 4096,
+          "base-light" => 2048,
+          "base" => 2048,
+          "embed-english-light-v2.0" => 512,
+          "embed-english-v2.0" => 512,
+          "embed-multilingual-v2.0" => 256,
+          "summarize-medium" => 2048,
+          "summarize-xlarge" => 2048
+        }.freeze
+        #
+        # Calculate the `max_tokens:` parameter to be set by calculating the context length of the text minus the prompt length
+        #
+        # @param content [String | Array<String>] The text or array of texts to validate
+        # @param model_name [String] The model name to validate against
+        # @return [Integer] Whether the text is valid or not
+        # @raise [TokenLimitExceeded] If the text is too long
+        #
+        def self.validate_max_tokens!(content, model_name, client)
+          text_token_length = if content.is_a?(Array)
+            content.sum { |item| token_length(item.to_json, model_name, client) }
+          else
+            token_length(content, model_name, client)
+          end
+
+          max_tokens = TOKEN_LIMITS[model_name] - text_token_length
+
+          # Raise an error even if whole prompt is equal to the model's token limit (max_tokens == 0) since not response will be returned
+          if max_tokens <= 0
+            raise TokenLimitExceeded, "This model's maximum context length is #{TOKEN_LIMITS[model_name]} tokens, but the given text is #{text_token_length} tokens long."
+          end
+
+          max_tokens
+        end
+
+        #
+        # Calculate token length for a given text and model name
+        #
+        # @param text [String] The text to calculate the token length for
+        # @param model_name [String] The model name to validate against
+        # @return [Integer] The token length of the text
+        #
+        def self.token_length(text, model_name, client)
+          res = client.tokenize(text: text)
+          res["tokens"].length
+        end
+      end
+    end
+  end
+end

--- a/spec/langchain/llm/cohere_spec.rb
+++ b/spec/langchain/llm/cohere_spec.rb
@@ -36,6 +36,26 @@ RSpec.describe Langchain::LLM::Cohere do
           "meta" => {"api_version" => {"version" => "1"}}
         }
       )
+
+      allow(subject.client).to receive(:tokenize).and_return(
+        {
+          "tokens" => [
+            33555,
+            1114,
+            34
+          ],
+          "token_strings" => [
+            "hello",
+            " world",
+            "!"
+          ],
+          "meta" => {
+            "api_version" => {
+              "version" => "1"
+            }
+          }
+        }
+      )
     end
 
     it "returns a completion" do
@@ -53,9 +73,11 @@ RSpec.describe Langchain::LLM::Cohere do
       it "passes correct options to the completions method" do
         expect(subject.client).to receive(:generate).with(
           {
+            max_tokens: 2045,
             model: "base-light",
             prompt: "Hello World",
-            temperature: 0.0
+            temperature: 0.0,
+            truncate: "START"
           }
         )
         subject.complete(prompt: "Hello World")

--- a/spec/langchain/utils/token_length/cohere_validator_spec.rb
+++ b/spec/langchain/utils/token_length/cohere_validator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Langchain::Utils::TokenLength::CohereValidator do
+  describe "#validate_max_tokens!" do
+    subject { described_class.validate_max_tokens!(content, model, client) }
+
+    context "with text argument" do
+      context "when the text is too long" do
+        let(:content) { "lorem ipsum" * 9000 }
+        let(:model) { "base" }
+        let(:client) { Langchain::LLM::Cohere.new(api_key: "123") }
+
+        before do
+          allow(described_class).to receive(:token_length).and_return(
+            4096
+          )
+        end
+
+        it "raises an error" do
+          expect {
+            subject
+          }.to raise_error(Langchain::Utils::TokenLength::TokenLimitExceeded, "This model's maximum context length is 2048 tokens, but the given text is 4096 tokens long.")
+        end
+      end
+
+      context "when the text is not too long" do
+        let(:content) { "lorem ipsum" * 10 }
+        let(:model) { "base" }
+        let(:client) { Langchain::LLM::Cohere.new(api_key: "123") }
+
+        before do
+          allow(described_class).to receive(:token_length).and_return(
+            790
+          )
+        end
+
+        it "does not raise an error" do
+          expect { subject }.not_to raise_error
+        end
+
+        it "returns the correct max_tokens" do
+          expect(subject).to eq(1258)
+        end
+      end
+    end
+
+    context "with array argument" do
+      let(:content) { ["lorem ipsum" * 10, "lorem ipsum" * 10] }
+      let(:model) { "base" }
+      let(:client) { Langchain::LLM::Cohere.new(api_key: "123") }
+
+      before do
+        allow(described_class).to receive(:token_length).and_return(
+          790
+        )
+      end
+
+      context "when the text is not too long" do
+        it "returns the correct max_tokens" do
+          expect(subject).to eq(468)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. add max token length validator for Cohere
2. add `truncate` to default_options
> During the test, Cohere `tokenize` API  returns an input with token length 252. The model `command` max token length is 4096, so I set the `max_tokens` to 4096 - 252 = 3844. But the `generate`'s return has 3846 token length, which exceeds the max allowed token length and throws an exception. So, I add the default `truncate` option to `START`.