### PR TITLE
Add distance parameter to weaviate similarity_search

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -17,7 +17,9 @@ weaviate = Langchain::Vectorsearch::Weaviate.new(
   url: ENV["WEAVIATE_URL"],
   api_key: ENV["WEAVIATE_API_KEY"],
   index_name: "",
-  llm: Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
+  llm: Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"]),
+  model_service: :openai,
+  model_api_key: ENV["OPENAI_API_KEY"]
 )
 
 qdrant = Langchain::Vectorsearch::Qdrant.new(

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -16,7 +16,7 @@ module Langchain::LLM
       dimension: 768, # This is what the `embedding-gecko-001` model generates
       completion_model_name: "text-bison-001",
       chat_completion_model_name: "chat-bison-001",
-      embeddings_model_name: "embedding-gecko-001"
+      embeddings_model_name: "textembedding-gecko" # "embedding-gecko-001"
     }.freeze
     LENGTH_VALIDATOR = Langchain::Utils::TokenLength::GooglePalmValidator
 

--- a/lib/langchain/vectorsearch/weaviate.rb
+++ b/lib/langchain/vectorsearch/weaviate.rb
@@ -8,7 +8,7 @@ module Langchain::Vectorsearch
     # Gem requirements: gem "weaviate-ruby", "~> 0.8.0"
     #
     # Usage:
-    # weaviate = Langchain::Vectorsearch::Weaviate.new(url:, api_key:, index_name:, llm:, llm_api_key:)
+    # weaviate = Langchain::Vectorsearch::Weaviate.new(url:, api_key:, index_name:, llm:, llm_api_key:, model_service:, model_api_key:)
     #
     VECTORIZERS = {
       # Source:
@@ -31,8 +31,6 @@ module Langchain::Vectorsearch
       depends_on "weaviate-ruby"
       require "weaviate"
 
-      @vectorizer = VECTORIZERS[model_service] || DEFAULT_VECTORIZER
-
       @client = ::Weaviate::Client.new(
         url: url,
         api_key: api_key,
@@ -43,6 +41,7 @@ module Langchain::Vectorsearch
       # Weaviate requires the class name to be Capitalized: https://weaviate.io/developers/weaviate/configuration/schema-configuration#create-a-class
       # TODO: Capitalize index_name
       @index_name = index_name
+      @vectorizer = VECTORIZERS[model_service] || DEFAULT_VECTORIZER
 
       super(llm: llm)
     end
@@ -87,7 +86,6 @@ module Langchain::Vectorsearch
     end
 
     # Create default schema
-    # To use a vectorizer other than "none" you need to set ENABLE_MODULES on the Weaviate server
     def create_default_schema
       client.schema.create(
         class_name: index_name,
@@ -101,6 +99,7 @@ module Langchain::Vectorsearch
     end
 
     # Return documents similar to the query
+    # Requires ENABLE_MODULES to be set on the Weaviate server
     # @param query [String] The query to search for
     # @param k [Integer|String] The number of results to return
     # @param distance [Integer|String] The maximum distance to search for
@@ -108,18 +107,18 @@ module Langchain::Vectorsearch
     def similarity_search(query:, k: 4, distance: nil)
       if distance
         near_text = "{ concepts: \"#{query}\" distance: #{distance} }"
-
-        client.query.get(
-          class_name: index_name,
-          near_text: near_text,
-          limit: k.to_s,
-          fields: "content _additional { id distance}"
-        )
+        fields = "__id content _additional { id distance}"
       else
-        embedding = llm.embed(text: query)
-
-        similarity_search_by_vector(embedding: embedding, k: k)
+        near_text = "{ concepts: \"#{query}\" }"
+        fields = "__id content _additional { id }"
       end
+
+      client.query.get(
+        class_name: index_name,
+        near_text: near_text,
+        limit: k.to_s,
+        fields: fields
+      )
     end
 
     # Return documents similar to the vector

--- a/lib/langchain/vectorsearch/weaviate.rb
+++ b/lib/langchain/vectorsearch/weaviate.rb
@@ -16,7 +16,8 @@ module Langchain::Vectorsearch
       openai: "text2vec-openai",
       azure_openai: "text2vec-openai",
       huggingface: "text2vec-hugingface",
-      cohere: "text2vec-cohere"
+      cohere: "text2vec-cohere",
+      google_palm: "text2vec-palm"
     }.freeze
     DEFAULT_VECTORIZER = :none
 

--- a/lib/langchain/vectorsearch/weaviate.rb
+++ b/lib/langchain/vectorsearch/weaviate.rb
@@ -64,11 +64,23 @@ module Langchain::Vectorsearch
     # Return documents similar to the query
     # @param query [String] The query to search for
     # @param k [Integer|String] The number of results to return
+    # @param distance [Integer|String] The maximum distance to search for
     # @return [Hash] The search results
-    def similarity_search(query:, k: 4)
-      embedding = llm.embed(text: query)
+    def similarity_search(query:, k: 4, distance: nil)
+      if distance
+        near_text = "{ concepts: \"#{query}\" distance: #{distance} }"
 
-      similarity_search_by_vector(embedding: embedding, k: k)
+        client.query.get(
+          class_name: index_name,
+          near_text: near_text,
+          limit: k.to_s,
+          fields: "content _additional { id distance}"
+        )
+      else
+        embedding = llm.embed(text: query)
+
+        similarity_search_by_vector(embedding: embedding, k: k)
+      end
     end
 
     # Return documents similar to the vector

--- a/lib/langchain/vectorsearch/weaviate.rb
+++ b/lib/langchain/vectorsearch/weaviate.rb
@@ -105,7 +105,7 @@ module Langchain::Vectorsearch
         class_name: index_name,
         vectorizer: @vectorizer,
         module_config: {
-          text2vecPalm: {
+          "text2vec-palm" => {
             projectId: @project_id
           }
         },

--- a/spec/langchain/vectorsearch/weaviate_spec.rb
+++ b/spec/langchain/vectorsearch/weaviate_spec.rb
@@ -103,17 +103,11 @@ RSpec.describe Langchain::Vectorsearch::Weaviate do
       ).to receive(:get)
         .with(
           class_name: "products",
-          near_vector: "{ vector: [-0.0018150936, 0.0017554426, -0.022715086] }",
+          near_text: "{ concepts: \"earth\" }",
           limit: "4",
           fields: "__id content _additional { id }"
         )
         .and_return(fixture)
-
-      allow(subject.llm).to receive(:embed).and_return([
-        -0.0018150936,
-        0.0017554426,
-        -0.022715086
-      ])
     end
 
     it "searches for similar texts" do

--- a/spec/langchain/vectorsearch/weaviate_spec.rb
+++ b/spec/langchain/vectorsearch/weaviate_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe Langchain::Vectorsearch::Weaviate do
       url: "http://localhost:8080",
       api_key: "123",
       index_name: "products",
-      llm: Langchain::LLM::OpenAI.new(api_key: "123")
+      llm: Langchain::LLM::OpenAI.new(api_key: "123"),
+      model_service: :openai,
+      model_api_key: "123"
     )
   }
 


### PR DESCRIPTION
<img width="1373" alt="image" src="https://github.com/andreibondarev/langchainrb/assets/5638339/ed2d4ec8-51f8-4ae3-a2ba-33939921c79a">

Is that error due to `vectorizer: "none"` below?
```ruby
  # Create default schema
    def create_default_schema
      client.schema.create(
        class_name: index_name,
        vectorizer: "none",
        properties: [
          # TODO: Allow passing in your own IDs
          {
            dataType: ["text"],
            name: "content"
          }
        ]
      )
    end
