### PR TITLE
fix: qdrant.rb

### DIFF
--- a/lib/langchain/vectorsearch/qdrant.rb
+++ b/lib/langchain/vectorsearch/qdrant.rb
@@ -32,11 +32,12 @@ module Langchain::Vectorsearch
     # Add a list of texts to the index
     # @param texts [Array] The list of texts to add
     # @return [Hash] The response from the server
-    def add_texts(texts:, ids:)
+    def add_texts(texts:, ids: [])
       batch = {ids: [], vectors: [], payloads: []}
 
       Array(texts).each_with_index do |text, i|
-        batch[:ids].push(ids[i] || SecureRandom.uuid)
+        id = ids[i] || SecureRandom.uuid
+        batch[:ids].push(id)
         batch[:vectors].push(llm.embed(text: text))
         batch[:payloads].push({content: text})
       end
@@ -109,7 +110,7 @@ module Langchain::Vectorsearch
     def ask(question:)
       search_results = similarity_search(query: question)
 
-      context = search_results.dig("result").map do |result|
+      context = search_results.map do |result|
         result.dig("payload").to_s
       end
       context = context.join("\n---\n")

--- a/spec/langchain/vectorsearch/qdrant_spec.rb
+++ b/spec/langchain/vectorsearch/qdrant_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Langchain::Vectorsearch::Qdrant do
     let(:answer) { "5 times" }
 
     before do
-      allow(subject).to receive(:similarity_search).with(query: question).and_return({"result" => [{"payload" => text}]})
+      allow(subject).to receive(:similarity_search).with(query: question).and_return([{"payload" => text}])
       allow(subject.llm).to receive(:chat).with(prompt: prompt).and_return(answer)
     end
 


### PR DESCRIPTION
Thank you for creating this Gem. I encountered a couple of bugs when trying to use Qdrant with VectorDatabase.
### my code
```test.rb
require 'langchainrb'
require 'qdrant'
require 'pry'

client = Langchain::Vectorsearch::Qdrant.new(
  url: '*********************',
  api_key: '*********************',
  index_name: 'test',
  llm: Langchain::LLM::OpenAI.new(api_key: '*********************')
)

client.create_default_schema

company_info = Langchain::Processors::JSON.new.parse(Langchain.root.join('/user/dev/embedding_sample/company_info.json'))

client.add_texts(
  texts: company_info.to_s
)

puts client.ask(
  question: "#{ARGV}"
)
```

- The first bug is related to the absence of default arguments in the 'add_texts' method, which caused an error.
```bash
/Users/satoru/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/langchainrb-0.6.3/lib/langchain/vectorsearch/qdrant.rb:35:in `add_texts': missing keyword: :ids (ArgumentError)
        from test_company_info.rb:19:in `<main>'
```

- The second bug was found in the 'ask' method while mapping the 'search_results' object. It was unnecessary to include the 'result' parameter, so I removed it.
```bash
/Users/satoru/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/langchainrb-0.6.3/lib/langchain/vectorsearch/qdrant.rb:113:in `dig': no implicit conversion of String into Integer (TypeError)
        from /Users/satoru/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/langchainrb-0.6.3/lib/langchain/vectorsearch/qdrant.rb:113:in `ask'
        from test_company_info.rb:24:in `<main>'
```