### PR TITLE
Allow loading multiple files from a directory

### DIFF
--- a/spec/fixtures/loaders/data/example.csv
+++ b/spec/fixtures/loaders/data/example.csv
@@ -1,0 +1,3 @@
+Username,Identifier,First name,Last name
+booker12,9012,Rachel,Booker
+grey07,2070,Laura,Grey

--- a/spec/fixtures/loaders/data/example.jsonl
+++ b/spec/fixtures/loaders/data/example.jsonl
@@ -1,0 +1,2 @@
+{"name": "Luke Skywalker", "height": "172", "mass": "77"}
+{"name": "C-3PO", "height": "167", "mass": "75"}

--- a/spec/fixtures/loaders/data/example.txt
+++ b/spec/fixtures/loaders/data/example.txt
@@ -1,0 +1,1 @@
+Lorem Ipsum is simply dummy text of the printing and typesetting industry.

--- a/spec/langchain/loader_spec.rb
+++ b/spec/langchain/loader_spec.rb
@@ -13,6 +13,30 @@ RSpec.describe Langchain::Loader do
       allow(URI).to receive(:parse).and_return(double(open: response))
     end
 
+    context "Directory" do
+      let(:path) { "spec/fixtures/loaders/data" }
+      let(:result) do
+        [
+          [
+            ["Username", "Identifier", "First name", "Last name"],
+            ["booker12", "9012", "Rachel", "Booker"],
+            ["grey07", "2070", "Laura", "Grey"]
+          ],
+          [
+            {"name" => "Luke Skywalker", "height" => "172", "mass" => "77"},
+            {"name" => "C-3PO", "height" => "167", "mass" => "75"}
+          ],
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry.\n"
+        ]
+      end
+
+      it "loads files from directory" do
+        expect(subject).to be_a(Array)
+
+        expect(subject.map(&:value)).to eq(result)
+      end
+    end
+
     context "Text" do
       context "from local file" do
         let(:path) { "spec/fixtures/loaders/example.txt" }


### PR DESCRIPTION
## Motivation
Allow passing a directory to the loader and load multiple files recursively.

## Changes
- Add `directory?` method to `Langchain::Loader`
- Recursively call a loader for each file in the directory
- Return an array of `Langchain::Data` objects in case if a directory path was passed