### PR TITLE
Raise an error when token calculation API call fails

### DIFF
--- a/lib/langchain/llm/base.rb
+++ b/lib/langchain/llm/base.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Langchain::LLM
+  class ApiError < StandardError; end
+
   # A LLM is a language model consisting of a neural network with many parameters (typically billions of weights or more), trained on large quantities of unlabeled text using self-supervised learning or semi-supervised learning.
   #
   # Langchain.rb provides a common interface to interact with all supported LLMs:

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -125,7 +125,7 @@ module Langchain::LLM
 
       response = client.chat(parameters: parameters)
 
-      raise "Chat completion failed: #{response}" if !response.empty? && response.dig("error")
+      raise Langchain::LLM::ApiError.new "Chat completion failed: #{response.dig("error", "message")}" if !response.empty? && response.dig("error")
 
       unless streaming
         response.dig("choices", 0, "message", "content")

--- a/lib/langchain/utils/token_length/google_palm_validator.rb
+++ b/lib/langchain/utils/token_length/google_palm_validator.rb
@@ -37,6 +37,9 @@ module Langchain
         #
         def self.token_length(text, model_name = "chat-bison-001", options)
           response = options[:llm].client.count_message_tokens(model: model_name, prompt: text)
+
+          raise Langchain::LLM::ApiError.new(response["error"]["message"]) unless response["error"].nil?
+
           response.dig("tokenCount")
         end
 

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -314,6 +314,18 @@ RSpec.describe Langchain::LLM::OpenAI do
         expect(subject.chat(prompt: prompt, model: model, temperature: temperature)).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
       end
     end
+
+    context "with failed API call" do
+      let(:response) do
+        {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
+      end
+
+      it "raises an error" do
+        expect {
+          subject.chat(prompt: prompt)
+        }.to raise_error(Langchain::LLM::ApiError, "Chat completion failed: User location is not supported for the API use.")
+      end
+    end
   end
 
   describe "#summarize" do

--- a/spec/langchain/utils/token_length/google_palm_validator_spec.rb
+++ b/spec/langchain/utils/token_length/google_palm_validator_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe Langchain::Utils::TokenLength::GooglePalmValidator do
   let(:llm) { Langchain::LLM::GooglePalm.new(api_key: "123") }
   let(:model) { "chat-bison-001" }
+  let(:token_length) { 200 }
+  let(:content) { "lorem ipsum" * 100 }
 
   before do
     allow(llm.client).to receive(:count_message_tokens).and_return(
@@ -14,6 +16,16 @@ RSpec.describe Langchain::Utils::TokenLength::GooglePalmValidator do
     subject { described_class.validate_max_tokens!(content, model, llm: llm) }
 
     context "with text argument" do
+      context "when the text is not too long" do
+        it "does not raise an error" do
+          expect { subject }.not_to raise_error
+        end
+
+        it "returns the correct max_tokens" do
+          expect(subject).to eq(3800)
+        end
+      end
+
       context "when the text is too long" do
         let(:token_length) { 4000 }
 
@@ -23,20 +35,6 @@ RSpec.describe Langchain::Utils::TokenLength::GooglePalmValidator do
           expect {
             subject
           }.to raise_error(Langchain::Utils::TokenLength::TokenLimitExceeded, "This model's maximum context length is 4000 tokens, but the given text is 4000 tokens long.")
-        end
-      end
-
-      context "when the text is not too long" do
-        let(:token_length) { 200 }
-
-        let(:content) { "lorem ipsum" * 100 }
-
-        it "does not raise an error" do
-          expect { subject }.not_to raise_error
-        end
-
-        it "returns the correct max_tokens" do
-          expect(subject).to eq(3800)
         end
       end
     end
@@ -50,6 +48,20 @@ RSpec.describe Langchain::Utils::TokenLength::GooglePalmValidator do
         it "returns the correct max_tokens" do
           expect(subject).to eq(3000)
         end
+      end
+    end
+
+    context "with failed API call" do
+      before do
+        allow(llm.client).to receive(:count_message_tokens).and_return(
+          {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "status" => "FAILED_PRECONDITION"}}
+        )
+      end
+
+      it "raises an error" do
+        expect {
+          subject
+        }.to raise_error(Langchain::LLM::ApiError, "User location is not supported for the API use.")
       end
     end
   end


### PR DESCRIPTION
Should make it clear that the API call failed instead of getting an error like https://github.com/andreibondarev/langchainrb/issues/238