### PR TITLE
Add support for baran gem's recursive text chunking

### DIFF
--- a/lib/langchain.rb
+++ b/lib/langchain.rb
@@ -82,6 +82,7 @@ module Langchain
   module Chunker
     autoload :Base, "langchain/chunker/base"
     autoload :Text, "langchain/chunker/text"
+    autoload :RecursiveText, "langchain/chunker/recursive_text"
   end
 
   module Tool

--- a/lib/langchain/chunker/recursive_text.rb
+++ b/lib/langchain/chunker/recursive_text.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "baran"
+
+module Langchain
+  module Chunker
+    #
+    # Recursive text chunker. Preferentially splits on separators.
+    #
+    # Usage:
+    #     Langchain::Chunker::RecursiveText.new(text).chunks
+    #
+    class RecursiveText < Base
+      attr_reader :text, :chunk_size, :chunk_overlap, :separators
+
+      # @param [String] text
+      # @param [Integer] chunk_size
+      # @param [Integer] chunk_overlap
+      # @param [Array<String>] separators
+      def initialize(text, chunk_size: 1000, chunk_overlap: 200, separators: ["\n\n"])
+        @text = text
+        @chunk_size = chunk_size
+        @chunk_overlap = chunk_overlap
+        @separators = separators
+      end
+
+      # @return [Array<String>]
+      def chunks
+        splitter = Baran::RecursiveCharacterTextSplitter.new(
+          chunk_size: chunk_size,
+          chunk_overlap: chunk_overlap,
+          separators: separators
+        )
+        splitter.chunks(text)
+      end
+    end
+  end
+end

--- a/spec/langchain/chunker/recursive_text_spec.rb
+++ b/spec/langchain/chunker/recursive_text_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Langchain::Chunker::RecursiveText do
+  let(:source) { "spec/fixtures/loaders/example.txt" }
+  let(:text) { File.read(source) }
+
+  subject {
+    described_class.new(text,
+      chunk_size: 1000,
+      chunk_overlap: 200,
+      separators: ["\n\n"])
+  }
+
+  describe "#chunks" do
+    it "returns an array of chunks" do
+      expect(Baran::RecursiveCharacterTextSplitter).to receive(:new).with(
+        chunk_size: 1000,
+        chunk_overlap: 200,
+        separators: ["\n\n"]
+      ).and_call_original
+
+      allow_any_instance_of(Baran::RecursiveCharacterTextSplitter).to receive(:chunks)
+        .with(text)
+        .and_call_original
+
+      subject.chunks
+    end
+  end
+end


### PR DESCRIPTION
Added `Langchain::Chunkers::RecursiveText`, which wraps `Baran::RecursiveCharacterTextSplitter`. Recursive text splitting preferentially splits on the provided separators array and then if the results are longer than the `chunk_size:`, splits those chunks into smaller chunks.