### PR TITLE
Update README.md for the contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ Join us in the [Langchain.rb](https://discord.gg/WDARp7J2n8) Discord server.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/andreibondarev/langchain.
+Bug reports and pull requests are welcome on GitHub at https://github.com/andreibondarev/langchainrb.
 
 ## License
 


### PR DESCRIPTION
The current link is missing the `rb` at the end of the repos name, leading to 404s

Just fixing a typo. This is my first time seeing this repo, and as a newer rails developer, I'd like to get more involved. Nice to meet everyone :)