### PR TITLE
Fix function calls

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -12,7 +12,6 @@ require "langchain"
 require "dotenv/load"
 require "pry-byebug"
 
-
 weaviate = Langchain::Vectorsearch::Weaviate.new(
   url: ENV["WEAVIATE_URL"],
   api_key: ENV["WEAVIATE_API_KEY"],

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Langchain::LLM::OpenAI do
     let(:model) { "gpt-3.5-turbo" }
     let(:temperature) { 0.0 }
     let(:history) { [content: prompt, role: "user"] }
-    let(:parameters) { {parameters: {messages: history, model: model, temperature: temperature, max_tokens: be_between(4015, 4096)}} }
+    let(:parameters) { {parameters: {messages: history, model: model, temperature: temperature, max_tokens: be_between(4014, 4096)}} }
     let(:answer) { "As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?" }
     let(:response) do
       {
@@ -334,7 +334,7 @@ RSpec.describe Langchain::LLM::OpenAI do
           let(:messages) do
             [
               {role: "user", content: "What is the weather like in Boston?"},
-              {role: "assistant", content: complete_response},
+              {role: "assistant", content: complete_response}
             ]
           end
           let(:history) do


### PR DESCRIPTION
The bug is that the history gets broken because of the `complete_response` feature which returns a `Hash` instead of a `String` and gets stored right away in the memory. The second time a message is sent it fails:

![image](https://github.com/andreibondarev/langchainrb/assets/6373536/185656ef-8a8a-4e88-ab0d-b9c0ad7af50c)

`
Chat completion failed: {'id': 'chatcmpl-7ilb1RYn4tXZ92N9vdLwhG9hPZInc', 'object': 'chat.completion', 'created': 1690903747, 'model': 'gpt-3.5-turbo-0613', 'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': 'Hi there! How can I assist you today?'}, 'finish_reason': 'stop'}], 'usage': {'prompt_tokens': 50, 'completion_tokens': 11, 'total_tokens': 61}} is not of type 'string' - 'messages.1.content' (Langchain::LLM::ApiError)
`

This solution is the "easiest" one in terms of changes required and backwards compatibility. But I'd consider refactoring the solution so that the LLMs objects don't return a simple string as the `response` and instead we always work with Hashes.

The `transform_messages` was adapted to match the example provided by OpenAI
![image](https://github.com/andreibondarev/langchainrb/assets/6373536/49b373b9-95c6-43f5-8bb2-b27e2df477b3)
https://openai.com/blog/function-calling-and-other-api-updates

I'd like to hear your thoughts on it before doing such change.