### PR TITLE
Cleans up an example which references an extraneous function property

### DIFF
--- a/examples/open_ai_qdrant_function_calls.rb
+++ b/examples/open_ai_qdrant_function_calls.rb
@@ -11,10 +11,6 @@ functions = [
         controller_name: {
           type: :string,
           description: "the controller name, e.g. users_controller"
-        },
-        unit: {
-          type: "string",
-          enum: %w[celsius fahrenheit]
         }
       },
       required: ["controller_name"]


### PR DESCRIPTION
Very small change. Looks like some content copied in from an earlier example.