### PR TITLE
The error message for attempting to load a non-existing file should name the file

### DIFF
--- a/lib/langchain/loader.rb
+++ b/lib/langchain/loader.rb
@@ -89,9 +89,9 @@ module Langchain
     end
 
     def load_from_path
-      raise FileNotFound unless File.exist?(@path)
+      return File.open(@path) if File.exist?(@path)
 
-      File.open(@path)
+      raise FileNotFound, "File #{@path} does not exist"
     end
 
     def load_from_directory(&block)


### PR DESCRIPTION
Small change for convenience. I had a script that loaded several files, and one didn't exist. This change would make the error message more informative.