### PR TITLE
Run tests in random order to prevent bigger issues in the future

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,5 +26,7 @@ RSpec.configure do |config|
   config.filter_run focus: !RUNNING_ON_CI
   config.run_all_when_everything_filtered = true
 
+  config.order = :random
+
   config.include CustomMatchers
 end


### PR DESCRIPTION
I think it's a [best practice to run tests in random order](https://github.com/rspec/rspec-core/pull/2929) to prevent dependencies between them.

BTW when running tests in this branch, it took only 2 runs to surface an issue
```
1) Langchain::LLM::OpenAI#initialize when llm_options are passed passes correct options to the client
     Failure/Error: expect(OpenAI.configuration.uri_base).to eq("http://localhost:1234")

       expected: "http://localhost:1234"
            got: "https://api.openai.com/"

       (compared using ==)
     # ./spec/langchain/llm/openai_spec.rb:22:in `block (4 levels) in <top (required)>'
```