### PR TITLE
rename tool_name and tool_description to name and description

### DIFF
--- a/lib/langchain/agent/react_agent/react_agent.rb
+++ b/lib/langchain/agent/react_agent/react_agent.rb
@@ -71,7 +71,7 @@ module Langchain::Agent
           action_input = response.match(/Action Input: "?(.*)"?/)&.send(:[], -1)
 
           # Find the Tool and call `execute`` with action_input as the input
-          tool = tools.find { |tool| tool.tool_name == action.strip }
+          tool = tools.find { |tool| tool.name == action.strip }
           Langchain.logger.info("Invoking \"#{tool.class}\" Tool with \"#{action_input}\"", for: self.class)
 
           # Call `execute` with action_input as the input

--- a/lib/langchain/agent/react_agent/react_agent.rb
+++ b/lib/langchain/agent/react_agent/react_agent.rb
@@ -100,15 +100,15 @@ module Langchain::Agent
     # @param tools [Array] Tools to use
     # @return [String] Prompt
     def create_prompt(question:, tools:)
-      tool_list = tools.map(&:tool_name)
+      tool_list = tools.map(&:name)
 
       prompt_template.format(
         date: Date.today.strftime("%B %d, %Y"),
         question: question,
         tool_names: "[#{tool_list.join(", ")}]",
         tools: tools.map do |tool|
-          tool_name = tool.tool_name
-          tool_description = tool.tool_description
+          tool_name = tool.name
+          tool_description = tool.description
           "#{tool_name}: #{tool_description}"
         end.join("\n")
       )

--- a/lib/langchain/tool/base.rb
+++ b/lib/langchain/tool/base.rb
@@ -53,7 +53,7 @@ module Langchain::Tool
     #
     # @return [String] tool name
     #
-    def tool_name
+    def name
       self.class.const_get(:NAME)
     end
 
@@ -68,7 +68,7 @@ module Langchain::Tool
     #
     # @return [String] tool description
     #
-    def tool_description
+    def description
       self.class.const_get(:DESCRIPTION)
     end
 
@@ -109,7 +109,7 @@ module Langchain::Tool
     #
     def self.validate_tools!(tools:)
       # Check if the tool count is equal to unique tool count
-      if tools.count != tools.map(&:tool_name).uniq.count
+      if tools.count != tools.map(&:name).uniq.count
         raise ArgumentError, "Either tools are not unique or are conflicting with each other"
       end
     end

--- a/spec/langchain/tool/calculator_spec.rb
+++ b/spec/langchain/tool/calculator_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Langchain::Tool::Calculator do
     end
   end
 
-  describe "#tool_name" do
+  describe "#name" do
     it "returns the tool name" do
-      expect(subject.tool_name).to eq("calculator")
+      expect(subject.name).to eq("calculator")
     end
   end
 end


### PR DESCRIPTION
I think its a bit redundant to have the `tool_` prefix on the tools attributes