### PR TITLE
Fix YARD warnings

### DIFF
--- a/lib/langchain/llm/llama_cpp.rb
+++ b/lib/langchain/llm/llama_cpp.rb
@@ -33,8 +33,8 @@ module Langchain::LLM
       @seed = seed
     end
 
-    # @params text [String] The text to embed
-    # @params n_threads [Integer] The number of CPU threads to use
+    # @param text [String] The text to embed
+    # @param n_threads [Integer] The number of CPU threads to use
     # @return [Array] The embedding
     def embed(text:, n_threads: nil)
       # contexts are kinda stateful when it comes to embeddings, so allocate one each time
@@ -49,9 +49,9 @@ module Langchain::LLM
       context.embeddings
     end
 
-    # @params prompt [String] The prompt to complete
-    # @params n_predict [Integer] The number of tokens to predict
-    # @params n_threads [Integer] The number of CPU threads to use
+    # @param prompt [String] The prompt to complete
+    # @param n_predict [Integer] The number of tokens to predict
+    # @param n_threads [Integer] The number of CPU threads to use
     # @return [String] The completed prompt
     def complete(prompt:, n_predict: 128, n_threads: nil)
       n_threads ||= self.n_threads

--- a/lib/langchain/output_parsers/base.rb
+++ b/lib/langchain/output_parsers/base.rb
@@ -9,7 +9,8 @@ module Langchain::OutputParsers
     # Parse the output of an LLM call.
     #
     # @param text - LLM output to parse.
-    # @returns Parsed output.
+    #
+    # @return [Object] Parsed output.
     #
     def parse(text:)
       raise NotImplementedError
@@ -18,9 +19,9 @@ module Langchain::OutputParsers
     #
     # Return a string describing the format of the output.
     #
-    # @returns Format instructions.
-    # @param options - Options for formatting instructions.
-    # @example
+    # @return [String] Format instructions.
+    #
+    # @example returns the format instructions
     # ```json
     # {
     #  "foo": "bar"

--- a/lib/langchain/output_parsers/fix.rb
+++ b/lib/langchain/output_parsers/fix.rb
@@ -65,7 +65,9 @@ module Langchain::OutputParsers
     #
     # Creates a new instance of the class using the given JSON::Schema.
     #
-    # @param schema [JSON::Schema] The JSON::Schema to use
+    # @param llm [Langchain::LLM] The LLM used in the fixing process
+    # @param parser [Langchain::OutputParsers] The parser originally used which resulted in parsing error
+    # @param prompt [Langchain::Prompt::PromptTemplate]
     #
     # @return [Object] A new instance of the class
     #


### PR DESCRIPTION
Currently, running `bundle exec yardoc` output many warnings, fixed with these changes