### PR TITLE
Set versions for open-ended dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       addressable (>= 2.8)
     language_server-protocol (3.17.0.3)
     lint_roller (1.0.0)
-    llama_cpp (0.3.0)
+    llama_cpp (0.3.7)
     loofah (2.21.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -332,7 +332,7 @@ DEPENDENCIES
   hnswlib (~> 0.8.1)
   hugging-face (~> 0.3.4)
   langchainrb!
-  llama_cpp
+  llama_cpp (~> 0.3.7)
   milvus (~> 0.9.0)
   nokogiri (~> 1.13)
   open-weather-ruby-client (~> 0.3.0)
@@ -343,7 +343,7 @@ DEPENDENCIES
   pry-byebug (~> 3.10.0)
   qdrant-ruby (~> 0.9.0)
   rake (~> 13.0)
-  rdiscount
+  rdiscount (~> 2.2.7)
   replicate-ruby (~> 0.2.2)
   roo (~> 2.10.0)
   rspec (~> 3.0)
@@ -354,7 +354,7 @@ DEPENDENCIES
   standardrb
   weaviate-ruby (~> 0.8.3)
   wikipedia-client (~> 1.17.0)
-  yard
+  yard (~> 0.9.34)
 
 BUNDLED WITH
    2.3.22

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -40,8 +40,8 @@ Gem::Specification.new do |spec|
   # development dependencies
   spec.add_development_dependency "dotenv-rails", "~> 2.7.6"
   spec.add_development_dependency "pry-byebug", "~> 3.10.0"
-  spec.add_development_dependency "yard"
-  spec.add_development_dependency "rdiscount" # for github-flavored markdown in yard
+  spec.add_development_dependency "yard", "~> 0.9.34"
+  spec.add_development_dependency "rdiscount", "~> 2.2.7" # for github-flavored markdown in yard
 
   # optional dependencies
   spec.add_development_dependency "ai21", "~> 0.2.1"
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "hnswlib", "~> 0.8.1"
   spec.add_development_dependency "hugging-face", "~> 0.3.4"
   spec.add_development_dependency "milvus", "~> 0.9.0"
-  spec.add_development_dependency "llama_cpp"
+  spec.add_development_dependency "llama_cpp", "~> 0.3.7"
   spec.add_development_dependency "nokogiri", "~> 1.13"
   spec.add_development_dependency "open-weather-ruby-client", "~> 0.3.0"
   spec.add_development_dependency "pg", "~> 1.5"


### PR DESCRIPTION
```
WARNING:  open-ended dependency on yard (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rdiscount (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on llama_cpp (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
```

If we don't set the versions we might get a broken CI because of changes on dependencies