### PR TITLE
Add k to pinecone's "ask" functionality

### DIFF
--- a/lib/langchain/vectorsearch/pinecone.rb
+++ b/lib/langchain/vectorsearch/pinecone.rb
@@ -142,7 +142,7 @@ module Langchain::Vectorsearch
     # @yield [String] Stream responses back one String at a time
     # @return [String] The answer to the question
     def ask(question:, namespace: "", filter: nil, k: 4, &block)
-      search_results = similarity_search(query: question, namespace: namespace, filter: filter)
+      search_results = similarity_search(query: question, namespace: namespace, filter: filter, k: k)
 
       context = search_results.map do |result|
         result.dig("metadata").to_s

--- a/lib/langchain/vectorsearch/pinecone.rb
+++ b/lib/langchain/vectorsearch/pinecone.rb
@@ -141,7 +141,7 @@ module Langchain::Vectorsearch
     # @param filter [String] The filter to use
     # @yield [String] Stream responses back one String at a time
     # @return [String] The answer to the question
-    def ask(question:, namespace: "", filter: nil, &block)
+    def ask(question:, namespace: "", filter: nil, k: 4, &block)
       search_results = similarity_search(query: question, namespace: namespace, filter: filter)
 
       context = search_results.map do |result|

--- a/spec/langchain/vectorsearch/pinecone_spec.rb
+++ b/spec/langchain/vectorsearch/pinecone_spec.rb
@@ -305,11 +305,12 @@ RSpec.describe Langchain::Vectorsearch::Pinecone do
     let(:question) { "How many times is \"lorem\" mentioned in this text?" }
     let(:prompt) { "Context:\n#{metadata}\n---\nQuestion: #{question}\n---\nAnswer:" }
     let(:answer) { "5 times" }
+    let(:k) { 4 }
 
     describe "without a namespace" do
       before do
         allow(subject).to receive(:similarity_search).with(
-          query: question, namespace: "", filter: nil
+          query: question, namespace: "", filter: nil, k: k
         ).and_return(matches)
         allow(subject.llm).to receive(:chat).with(prompt: prompt).and_return(answer)
       end
@@ -322,7 +323,7 @@ RSpec.describe Langchain::Vectorsearch::Pinecone do
     describe "with a namespace" do
       before do
         allow(subject).to receive(:similarity_search).with(
-          query: question, namespace: namespace, filter: nil
+          query: question, namespace: namespace, filter: nil, k: k
         ).and_return(matches)
         allow(subject.llm).to receive(:chat).with(prompt: prompt).and_return(answer)
       end
@@ -335,7 +336,7 @@ RSpec.describe Langchain::Vectorsearch::Pinecone do
     describe "with a filter" do
       before do
         allow(subject).to receive(:similarity_search).with(
-          query: question, namespace: "", filter: filter
+          query: question, namespace: "", filter: filter, k: k
         ).and_return(matches)
         allow(subject.llm).to receive(:chat).with(prompt: prompt).and_return(answer)
       end


### PR DESCRIPTION
We were running into an issue when asking a question of OpenAI using pinecone, where there were occasions where the context provided by the `ask` method was over the 4096 tokens, and so was exceeding the default OpenAI context window for question asking. This change would allow a user to add in an additional parameter `k` to the ask method, which could be subsequently passed to `similarity_search` to allow the user to have the amount of relevant results they wish, instead of defaulting to the 4 that is with `similarity_search` currently.