### PR TITLE
Add k to all asks

### DIFF
--- a/lib/langchain/vectorsearch/chroma.rb
+++ b/lib/langchain/vectorsearch/chroma.rb
@@ -113,10 +113,11 @@ module Langchain::Vectorsearch
 
     # Ask a question and return the answer
     # @param question [String] The question to ask
+    # @param k [Integer] The number of results to have in context
     # @yield [String] Stream responses back one String at a time
     # @return [String] The answer to the question
-    def ask(question:, &block)
-      search_results = similarity_search(query: question)
+    def ask(question:, k: 4, &block)
+      search_results = similarity_search(query: question, k: k)
 
       context = search_results.map do |result|
         result.document

--- a/lib/langchain/vectorsearch/milvus.rb
+++ b/lib/langchain/vectorsearch/milvus.rb
@@ -138,10 +138,11 @@ module Langchain::Vectorsearch
 
     # Ask a question and return the answer
     # @param question [String] The question to ask
+    # @param k [Integer] The number of results to have in context
     # @yield [String] Stream responses back one String at a time
     # @return [String] The answer to the question
-    def ask(question:, &block)
-      search_results = similarity_search(query: question)
+    def ask(question:, k: 4, &block)
+      search_results = similarity_search(query: question, k: k)
 
       content_field = search_results.dig("results", "fields_data").select { |field| field.dig("field_name") == "content" }
       content_data = content_field.first.dig("Field", "Scalars", "Data", "StringData", "data")

--- a/lib/langchain/vectorsearch/pgvector.rb
+++ b/lib/langchain/vectorsearch/pgvector.rb
@@ -135,10 +135,11 @@ module Langchain::Vectorsearch
 
     # Ask a question and return the answer
     # @param question [String] The question to ask
+    # @param k [Integer] The number of results to have in context
     # @yield [String] Stream responses back one String at a time
     # @return [String] The answer to the question
-    def ask(question:, &block)
-      search_results = similarity_search(query: question)
+    def ask(question:, k: 4, &block)
+      search_results = similarity_search(query: question, k: k)
 
       context = search_results.map do |result|
         result.content.to_s

--- a/lib/langchain/vectorsearch/pinecone.rb
+++ b/lib/langchain/vectorsearch/pinecone.rb
@@ -138,6 +138,7 @@ module Langchain::Vectorsearch
     # Ask a question and return the answer
     # @param question [String] The question to ask
     # @param namespace [String] The namespace to search in
+    # @param k [Integer] The number of results to have in context
     # @param filter [String] The filter to use
     # @yield [String] Stream responses back one String at a time
     # @return [String] The answer to the question

--- a/lib/langchain/vectorsearch/qdrant.rb
+++ b/lib/langchain/vectorsearch/qdrant.rb
@@ -112,10 +112,11 @@ module Langchain::Vectorsearch
 
     # Ask a question and return the answer
     # @param question [String] The question to ask
+    # @param k [Integer] The number of results to have in context
     # @yield [String] Stream responses back one String at a time
     # @return [String] The answer to the question
-    def ask(question:, &block)
-      search_results = similarity_search(query: question)
+    def ask(question:, k: 4, &block)
+      search_results = similarity_search(query: question, k: k)
 
       context = search_results.map do |result|
         result.dig("payload").to_s

--- a/lib/langchain/vectorsearch/weaviate.rb
+++ b/lib/langchain/vectorsearch/weaviate.rb
@@ -124,10 +124,11 @@ module Langchain::Vectorsearch
 
     # Ask a question and return the answer
     # @param question [String] The question to ask
+    # @param k [Integer] The number of results to have in context
     # @yield [String] Stream responses back one String at a time
     # @return [Hash] The answer
-    def ask(question:, &block)
-      search_results = similarity_search(query: question)
+    def ask(question:, k: 4, &block)
+      search_results = similarity_search(query: question, k: k)
 
       context = search_results.map do |result|
         result.dig("content").to_s

--- a/spec/langchain/vectorsearch/chroma_spec.rb
+++ b/spec/langchain/vectorsearch/chroma_spec.rb
@@ -117,9 +117,10 @@ RSpec.describe Langchain::Vectorsearch::Chroma do
     let(:question) { "How many times is 'lorem' mentioned in this text?" }
     let(:prompt) { "Context:\n#{text}\n---\nQuestion: #{question}\n---\nAnswer:" }
     let(:answer) { "5 times" }
+    let(:k) { 4 }
 
     before do
-      allow(subject).to receive(:similarity_search).with(query: question).and_return(results)
+      allow(subject).to receive(:similarity_search).with(query: question, k: k).and_return(results)
     end
 
     context "without block" do

--- a/spec/langchain/vectorsearch/milvus_spec.rb
+++ b/spec/langchain/vectorsearch/milvus_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Langchain::Vectorsearch::Milvus do
   let(:query) { "Greetings Earth" }
   let(:results) {
     {
-      collection_name: 'earthlings',
-      num_rows: 1,
+      "collection_name" => 'earthlings',
+      "num_rows" => 1,
       "results" => {
         "fields_data" => [
           {
@@ -70,8 +70,8 @@ RSpec.describe Langchain::Vectorsearch::Milvus do
             }
           }, {
             "field_name" => "vectors",
-            type: ::Milvus::DATA_TYPES["float_vector"],
-            field: [0, 1, 2]
+            "type" => ::Milvus::DATA_TYPES["float_vector"],
+            "field" => [0, 1, 2]
           }
         ]
       }

--- a/spec/langchain/vectorsearch/milvus_spec.rb
+++ b/spec/langchain/vectorsearch/milvus_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Langchain::Vectorsearch::Milvus do
   end
 
   describe "#ask" do
-    let(:question) { "How many times is "lorem" mentioned in this text?" }
+    let(:question) { 'How many times is "lorem" mentioned in this text?' }
     let(:prompt) { "Context:\n#{text}\n---\nQuestion: #{question}\n---\nAnswer:" }
     let(:answer) { "5 times" }
     let(:k) { 4 }

--- a/spec/langchain/vectorsearch/milvus_spec.rb
+++ b/spec/langchain/vectorsearch/milvus_spec.rb
@@ -53,17 +53,17 @@ RSpec.describe Langchain::Vectorsearch::Milvus do
   let(:query) { "Greetings Earth" }
   let(:results) {
     {
-      "collection_name" => 'earthlings',
+      "collection_name" => "earthlings",
       "num_rows" => 1,
       "results" => {
         "fields_data" => [
           {
-            'field_name' => "content",
-            'Field' => {
-              'Scalars' => {
-                'Data' => {
-                  'StringData' => {
-                    'data' => ['Hello World']
+            "field_name" => "content",
+            "Field" => {
+              "Scalars" => {
+                "Data" => {
+                  "StringData" => {
+                    "data" => ["Hello World"]
                   }
                 }
               }
@@ -113,7 +113,7 @@ RSpec.describe Langchain::Vectorsearch::Milvus do
   end
 
   describe "#ask" do
-    let(:question) { "How many times is 'lorem' mentioned in this text?" }
+    let(:question) { "How many times is "lorem" mentioned in this text?" }
     let(:prompt) { "Context:\n#{text}\n---\nQuestion: #{question}\n---\nAnswer:" }
     let(:answer) { "5 times" }
     let(:k) { 4 }

--- a/spec/langchain/vectorsearch/pgvector_spec.rb
+++ b/spec/langchain/vectorsearch/pgvector_spec.rb
@@ -161,6 +161,7 @@ if ENV["POSTGRES_URL"]
       let(:text) { "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor." }
       let(:prompt) { "Context:\n#{text}\n---\nQuestion: #{question}\n---\nAnswer:" }
       let(:answer) { "5 times" }
+      let(:k) { 4 }
 
       before do
         allow_any_instance_of(
@@ -189,7 +190,7 @@ if ENV["POSTGRES_URL"]
         end
 
         it "asks a question and returns the answer" do
-          expect(subject.ask(question: question)).to eq(answer)
+          expect(subject.ask(question: question, k: k)).to eq(answer)
         end
       end
 

--- a/spec/langchain/vectorsearch/qdrant_spec.rb
+++ b/spec/langchain/vectorsearch/qdrant_spec.rb
@@ -99,9 +99,10 @@ RSpec.describe Langchain::Vectorsearch::Qdrant do
     let(:question) { "How many times is 'lorem' mentioned in this text?" }
     let(:prompt) { "Context:\n#{text}\n---\nQuestion: #{question}\n---\nAnswer:" }
     let(:answer) { "5 times" }
+    let(:k) { 4 }
 
     before do
-      allow(subject).to receive(:similarity_search).with(query: question).and_return([{"payload" => text}])
+      allow(subject).to receive(:similarity_search).with(query: question, k: k).and_return([{"payload" => text}])
     end
 
     context "without block" do
@@ -110,7 +111,7 @@ RSpec.describe Langchain::Vectorsearch::Qdrant do
       end
 
       it "asks a question and returns the answer" do
-        expect(subject.ask(question: question)).to eq(answer)
+        expect(subject.ask(question: question, k: k)).to eq(answer)
       end
     end
 
@@ -128,7 +129,7 @@ RSpec.describe Langchain::Vectorsearch::Qdrant do
       it "asks a question and yields the chunk to the block" do
         expect do
           captured_output = capture(:stdout) do
-            subject.ask(question: question, &block)
+            subject.ask(question: question, k: k, &block)
           end
           expect(captured_output).to match(/Received chunk from llm.chat/)
         end

--- a/spec/langchain/vectorsearch/weaviate_spec.rb
+++ b/spec/langchain/vectorsearch/weaviate_spec.rb
@@ -167,10 +167,12 @@ RSpec.describe Langchain::Vectorsearch::Weaviate do
     let(:prompt) { "Context:\n#{matches[0]["content"]}\n---\nQuestion: #{question}\n---\nAnswer:" }
     let(:question) { "How many times is \"lorem\" mentioned in this text?" }
     let(:answer) { "5 times" }
+    let(:k) { 4 }
 
     before do
       allow(subject).to receive(:similarity_search).with(
-        query: question
+        query: question,
+        k: k
       ).and_return(matches)
     end
 
@@ -180,7 +182,7 @@ RSpec.describe Langchain::Vectorsearch::Weaviate do
       end
 
       it "asks a question and returns the answer" do
-        expect(subject.ask(question: question)).to eq(answer)
+        expect(subject.ask(question: question, k: k)).to eq(answer)
       end
     end
 
@@ -198,7 +200,7 @@ RSpec.describe Langchain::Vectorsearch::Weaviate do
       it "asks a question and yields the chunk to the block" do
         expect do
           captured_output = capture(:stdout) do
-            subject.ask(question: question, &block)
+            subject.ask(question: question, k: k, &block)
           end
           expect(captured_output).to match(/Received chunk from llm.chat/)
         end


### PR DESCRIPTION
### Context
This PR is the logical extension of https://github.com/andreibondarev/langchainrb/pull/297 - we were running into limits with the `ask` method where our context was larger than the 4096 token window available for our OpenAI model, and so we needed to slim it down by reducing the amount of results we received. However there was no `k` available on the method, so this gives all those methods that functionality.