### PR TITLE
Add find to pinecone

### DIFF
--- a/lib/langchain/vectorsearch/pinecone.rb
+++ b/lib/langchain/vectorsearch/pinecone.rb
@@ -31,6 +31,19 @@ module Langchain::Vectorsearch
       super(llm: llm)
     end
 
+    # Find records by ids
+    # @param ids [Array] The ids to find
+    # @param namespace String The namespace to search through
+    # @return [Hash] The response from the server
+    def find(ids: [], namespace: "")
+      raise ArgumentError, "Ids must be provided" if Array(ids).empty?
+
+      client.index(index_name).fetch(
+        ids: ids,
+        namespace: namespace
+      )
+    end
+
     # Add a list of texts to the index
     # @param texts [Array] The list of texts to add
     # @param ids [Array] The list of IDs to add

--- a/spec/langchain/vectorsearch/pinecone_spec.rb
+++ b/spec/langchain/vectorsearch/pinecone_spec.rb
@@ -93,6 +93,26 @@ RSpec.describe Langchain::Vectorsearch::Pinecone do
       allow(subject.client).to receive(:index).with(index_name).and_return(Pinecone::Index.new)
     end
 
+    describe "#find" do
+      let(:index) { Pinecone::Index.new }
+
+      before(:each) do
+        allow(subject.client).to receive(:index).and_return(index)
+        allow(subject.client.index).to receive(:fetch).and_return(vectors)
+        allow_any_instance_of(Pinecone::Index).to receive(:upsert).with(
+          vectors: vectors, namespace: namespace
+        ).and_return(true)
+      end
+
+      it "returns ArgumentError if no ids supplied" do
+        expect {subject.find(ids: []) }.to raise_error(ArgumentError, /Ids must be provided/)
+      end
+
+      it "finds vectors with the correct ids and namespace" do
+        expect(subject.find(ids: ['123'], namespace: namespace)).to eq(vectors)
+      end
+    end
+
     describe "without a namespace" do
       before(:each) do
         allow_any_instance_of(Pinecone::Index).to receive(:upsert).with(

--- a/spec/langchain/vectorsearch/pinecone_spec.rb
+++ b/spec/langchain/vectorsearch/pinecone_spec.rb
@@ -105,11 +105,11 @@ RSpec.describe Langchain::Vectorsearch::Pinecone do
       end
 
       it "returns ArgumentError if no ids supplied" do
-        expect {subject.find(ids: []) }.to raise_error(ArgumentError, /Ids must be provided/)
+        expect { subject.find(ids: []) }.to raise_error(ArgumentError, /Ids must be provided/)
       end
 
       it "finds vectors with the correct ids and namespace" do
-        expect(subject.find(ids: ['123'], namespace: namespace)).to eq(vectors)
+        expect(subject.find(ids: ["123"], namespace: namespace)).to eq(vectors)
       end
     end
 


### PR DESCRIPTION
### Context

This adds a `find` method to get the vector information back from pinecone based on the ids of the vectors you are looking for