### PR TITLE
Handle OpenAI API errors

### DIFF
--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Langchain::LLM::OpenAI do
     end
 
     context "with failed API call" do
-      let(:parameters)  do
+      let(:parameters) do
         {parameters: {model: "text-davinci-003", prompt: "Hello World", temperature: 0.0, max_tokens: 4095}}
       end
       let(:response) do
@@ -150,7 +150,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
       it "raises an error" do
         expect {
-          subject.complete(prompt: 'Hello World')
+          subject.complete(prompt: "Hello World")
         }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
       end
     end

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -139,6 +139,21 @@ RSpec.describe Langchain::LLM::OpenAI do
         expect(subject.complete(prompt: "Hello World", model: "text-curie-001", temperature: 1.0)).to eq("\n\nThe meaning of life is subjective and can vary from person to person.")
       end
     end
+
+    context "with failed API call" do
+      let(:parameters)  do
+        {parameters: {model: "text-davinci-003", prompt: "Hello World", temperature: 0.0, max_tokens: 4095}}
+      end
+      let(:response) do
+        {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
+      end
+
+      it "raises an error" do
+        expect {
+          subject.complete(prompt: 'Hello World')
+        }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
+      end
+    end
   end
 
   describe "#default_dimension" do
@@ -333,7 +348,7 @@ RSpec.describe Langchain::LLM::OpenAI do
       it "raises an error" do
         expect {
           subject.chat(prompt: prompt)
-        }.to raise_error(Langchain::LLM::ApiError, "Chat completion failed: User location is not supported for the API use.")
+        }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
       end
     end
   end


### PR DESCRIPTION
## Motivation
Currently, if OpenAI API returns an error langchainrb's  `complete` method just returns `nil` and `chat` raises an error. Making this behavior consistent across all methods so that developers actually see an error. 

## Changes
- Add `with_api_error_handling` method to OpenAI LLM that checks for errors in API responses
- Add test cases 