### PR TITLE
Update OpenAI completion to use chat API endpoint

### DIFF
--- a/spec/langchain/conversation_spec.rb
+++ b/spec/langchain/conversation_spec.rb
@@ -251,8 +251,8 @@ RSpec.describe Langchain::Conversation do
         {"choices" => [{"message" => {"content" => "I'm doing well. How about you?"}}]}
       end
       let(:context) { "You are a chatbot" }
-      let(:summary1) { {"choices" => [{"text" => "Just chatting about life"}]} }
-      let(:summary2) { {"choices" => [{"text" => "Nothing interesting here"}]} }
+      let(:summary1) { "Just chatting about life" }
+      let(:summary2) { "Nothing interesting here" }
       let(:examples) { [Langchain::HumanMessage.new("Hello"), Langchain::AIMessage.new("Hi")] }
       let(:messages) do
         [
@@ -268,7 +268,7 @@ RSpec.describe Langchain::Conversation do
       before do
         allow(llm).to receive(:client).and_return(client)
         allow(client).to receive(:chat).and_return(response)
-        allow(client).to receive(:completions).and_return(summary1, summary2)
+        allow(llm).to receive(:summarize).and_return(summary1, summary2)
 
         subject.set_context(context)
         subject.add_examples(examples)

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
       it "raises an error" do
         expect {
-          subject.complete(prompt: "Hello World")
+          subject.complete(prompt: 'Hello World')
         }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
       end
     end

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with failed API call" do
       let(:parameters) do
-        {parameters: {model: "text-davinci-003", prompt: "Hello World", temperature: 0.0, max_tokens: 4095}}
+        {parameters: {model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 0.0, max_tokens: 4086}}
       end
       let(:response) do
         {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}


### PR DESCRIPTION
## Motivation
Completions API is deprecated. Models used for text completions are going to be shut down on 4 Jan 2024  https://platform.openai.com/docs/deprecations/2023-07-06-gpt-and-embeddings 

OpenAI recommends using chat endpoint instead.

## Changes
- Switch LLM's `complete ` method to using `chat` endpoint (using chat method on OpenAI client) and chat_completion_model by default.
- Update complete tests accordingly

## Notes
Depends on https://github.com/andreibondarev/langchainrb/pull/311