### PR TITLE
Chroma DB - Fix metadata dictionary type

### DIFF
--- a/lib/langchain/vectorsearch/chroma.rb
+++ b/lib/langchain/vectorsearch/chroma.rb
@@ -37,7 +37,7 @@ module Langchain::Vectorsearch
           id: ids[i] ? ids[i].to_s : SecureRandom.uuid,
           embedding: llm.embed(text: text),
           # TODO: Add support for passing metadata
-          metadata: [], # metadatas[index],
+          metadata: {}, # metadatas[index],
           document: text # Do we actually need to store the whole original document?
         )
       end


### PR DESCRIPTION
This PR fixes a small issue with Chroma while calling `add_texts`

```
[2023-09-27T19:14:37.601876 #973095] ERROR -- : message=Client error response code=422 body={"detail":[{"type":"dict_type","loc":["body","metadatas",0],"msg":"Input should be a valid dictionary","input":[],"url":"https://errors.pydantic.dev/2.4/v/dict_type"}]}
/home/acid/.rvm/gems/ruby-3.2.2/gems/chroma-db-0.6.0/lib/chroma/resources/collection.rb:372:in `raise_failure_error': Chroma::APIError
        from /home/acid/.rvm/gems/ruby-3.2.2/gems/chroma-db-0.6.0/lib/chroma/resources/collection.rb:119:in `add'
        from /home/acid/.rvm/gems/ruby-3.2.2/gems/langchainrb-0.6.15/lib/langchain/vectorsearch/chroma.rb:46:in `add_texts'
        from chroma.rb:23:in `<main>'
```