### PR TITLE
👷‍♂️ Conversations: Decouple LLMs from Conversations [Part 2]

### DIFF
--- a/lib/langchain/conversation.rb
+++ b/lib/langchain/conversation.rb
@@ -57,9 +57,8 @@ module Langchain
     # @param message [String] The prompt to message the model with
     # @return [Response] The response from the model
     def message(message)
-      human_message = ::Langchain::Conversation::Prompt.new(message)
-      @memory.append_message(human_message)
-      ai_message = llm_response(human_message)
+      @memory.append_message ::Langchain::Conversation::Prompt.new(message)
+      ai_message = ::Langchain::Conversation::Response.new(llm_response)
       @memory.append_message(ai_message)
       ai_message
     end
@@ -84,8 +83,8 @@ module Langchain
 
     private
 
-    def llm_response(prompt)
-      @llm.chat(messages: @memory.messages, context: @memory.context, examples: @memory.examples, **@options, &@block)
+    def llm_response
+      @llm.chat(messages: @memory.messages.map(&:to_h), context: @memory.context&.to_s, examples: @memory.examples.map(&:to_h), **@options, &@block)
     rescue Langchain::Utils::TokenLength::TokenLimitExceeded => exception
       @memory.reduce_messages(exception)
       retry

--- a/lib/langchain/conversation/context.rb
+++ b/lib/langchain/conversation/context.rb
@@ -3,9 +3,6 @@
 module Langchain
   class Conversation
     class Context < Message
-      def type
-        "system"
-      end
     end
   end
 end

--- a/lib/langchain/conversation/message.rb
+++ b/lib/langchain/conversation/message.rb
@@ -5,17 +5,30 @@ module Langchain
     class Message
       attr_reader :content, :additional_kwargs
 
+      ROLE_MAPPING = {
+        context: "system",
+        prompt: "user",
+        response: "assistant"
+      }
+
       def initialize(content, additional_kwargs = nil)
         @content = content
         @additional_kwargs = additional_kwargs
       end
 
-      def type
-        raise NotImplementedError
+      def role
+        ROLE_MAPPING[type]
       end
 
       def to_s
         content
+      end
+
+      def to_h
+        {
+          role: role,
+          content: content
+        }
       end
 
       def ==(other)
@@ -23,14 +36,17 @@ module Langchain
       end
 
       def to_json(options = {})
-        hash = {
-          type: type,
-          content: content
-        }
+        hash = to_h
 
         hash[:additional_kwargs] = additional_kwargs unless additional_kwargs.nil? || additional_kwargs.empty?
 
         hash.to_json
+      end
+
+      private
+
+      def type
+        self.class.to_s.split("::").last.downcase.to_sym
       end
     end
   end

--- a/lib/langchain/conversation/prompt.rb
+++ b/lib/langchain/conversation/prompt.rb
@@ -3,9 +3,6 @@
 module Langchain
   class Conversation
     class Prompt < Message
-      def type
-        "human"
-      end
     end
   end
 end

--- a/lib/langchain/conversation/response.rb
+++ b/lib/langchain/conversation/response.rb
@@ -3,9 +3,6 @@
 module Langchain
   class Conversation
     class Response < Message
-      def type
-        "ai"
-      end
     end
   end
 end

--- a/lib/langchain/llm/google_palm.rb
+++ b/lib/langchain/llm/google_palm.rb
@@ -20,7 +20,7 @@ module Langchain::LLM
     }.freeze
     LENGTH_VALIDATOR = Langchain::Utils::TokenLength::GooglePalmValidator
     ROLE_MAPPING = {
-      "human" => "user"
+      "assistant" => "ai"
     }
 
     def initialize(api_key:, default_options: {})
@@ -74,12 +74,12 @@ module Langchain::LLM
     #
     # Generate a chat completion for a given prompt
     #
-    # @param prompt [Prompt] The prompt to generate a chat completion for
-    # @param messages [Array<Prompt|Response>] The messages that have been sent in the conversation
-    # @param context [Context] An initial context to provide as a system message, ie "You are RubyGPT, a helpful chat bot for helping people learn Ruby"
-    # @param examples [Array<Prompt|Response>] Examples of messages to provide to the model. Useful for Few-Shot Prompting
+    # @param prompt [String] The prompt to generate a chat completion for
+    # @param messages [Array<Hash>] The messages that have been sent in the conversation
+    # @param context [String] An initial context to provide as a system message, ie "You are RubyGPT, a helpful chat bot for helping people learn Ruby"
+    # @param examples [Array<Hash>] Examples of messages to provide to the model. Useful for Few-Shot Prompting
     # @param options [Hash] extra parameters passed to GooglePalmAPI::Client#generate_chat_message
-    # @return [Response] The chat completion
+    # @return [String] The chat completion
     #
     def chat(prompt: "", messages: [], context: "", examples: [], **options)
       raise ArgumentError.new(":prompt or :messages argument is expected") if prompt.empty? && messages.empty?
@@ -87,7 +87,7 @@ module Langchain::LLM
       default_params = {
         temperature: @defaults[:temperature],
         model: @defaults[:chat_completion_model_name],
-        context: context.to_s,
+        context: context,
         messages: compose_chat_messages(prompt: prompt, messages: messages),
         examples: compose_examples(examples)
       }
@@ -108,7 +108,7 @@ module Langchain::LLM
       response = client.generate_chat_message(**default_params)
       raise "GooglePalm API returned an error: #{response}" if response.dig("error")
 
-      ::Langchain::Conversation::Response.new(response.dig("candidates", 0, "content"))
+      response.dig("candidates", 0, "content")
     end
 
     #
@@ -150,8 +150,8 @@ module Langchain::LLM
     def compose_examples(examples)
       examples.each_slice(2).map do |example|
         {
-          input: {content: example.first.content},
-          output: {content: example.last.content}
+          input: {content: example.first[:content]},
+          output: {content: example.last[:content]}
         }
       end
     end
@@ -159,8 +159,8 @@ module Langchain::LLM
     def transform_messages(messages)
       messages.map do |message|
         {
-          author: ROLE_MAPPING.fetch(message.type, message.type),
-          content: message.content
+          author: ROLE_MAPPING.fetch(message[:role], message[:role]),
+          content: message[:content]
         }
       end
     end

--- a/spec/langchain/conversation_spec.rb
+++ b/spec/langchain/conversation_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Langchain::Conversation do
     let(:context) { "You are a chatbot" }
     let(:examples) { [Langchain::Conversation::Prompt.new("Hello"), Langchain::Conversation::Response.new("Hi")] }
     let(:prompt) { "How are you doing?" }
-    let(:response) { Langchain::Conversation::Response.new("I'm doing well. How about you?") }
+    let(:response) { "I'm doing well. How about you?" }
 
     context "with stream: true option and block passed in" do
       let(:block) { proc { |chunk| print(chunk) } }
@@ -47,7 +47,7 @@ RSpec.describe Langchain::Conversation do
           &block
         ).and_return(response)
 
-        expect(conversation.message(prompt)).to eq(response)
+        expect(conversation.message(prompt)).to eq(Langchain::Conversation::Response.new(response))
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe Langchain::Conversation do
           messages: [Langchain::Conversation::Prompt.new(prompt)]
         ).and_return(response)
 
-        expect(subject.message(prompt)).to eq(response)
+        expect(subject.message(prompt)).to eq(Langchain::Conversation::Response.new(response))
       end
     end
 
@@ -70,12 +70,12 @@ RSpec.describe Langchain::Conversation do
 
       it "messages the model and returns the response" do
         expect(llm).to receive(:chat).with(
-          context: Langchain::Conversation::Context.new(context),
+          context: context,
           examples: [],
-          messages: [Langchain::Conversation::Prompt.new(prompt)]
+          messages: [{role: "user", content: prompt}]
         ).and_return(response)
 
-        expect(subject.message(prompt)).to eq(response)
+        expect(subject.message(prompt)).to eq(Langchain::Conversation::Response.new(response))
       end
     end
 
@@ -87,17 +87,15 @@ RSpec.describe Langchain::Conversation do
 
       it "messages the model and returns the response" do
         expect(llm).to receive(:chat).with(
-          context: Langchain::Conversation::Context.new(context),
+          context: context,
           examples: [
-            Langchain::Conversation::Prompt.new("Hello"),
-            Langchain::Conversation::Response.new("Hi")
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi"}
           ],
-          messages: [
-            Langchain::Conversation::Prompt.new(prompt)
-          ]
+          messages: [{role: "user", content: prompt}]
         ).and_return(response)
 
-        expect(subject.message(prompt)).to eq(response)
+        expect(subject.message(prompt)).to eq(Langchain::Conversation::Response.new(response))
       end
     end
 
@@ -108,11 +106,11 @@ RSpec.describe Langchain::Conversation do
         expect(llm).to receive(:chat).with(
           context: nil,
           examples: [],
-          messages: [Langchain::Conversation::Prompt.new(prompt)],
+          messages: [{role: "user", content: prompt}],
           temperature: 0.7
         ).and_return(response)
 
-        expect(subject.message(prompt)).to eq(response)
+        expect(subject.message(prompt)).to eq(Langchain::Conversation::Response.new(response))
       end
     end
 

--- a/spec/langchain/llm/google_palm_spec.rb
+++ b/spec/langchain/llm/google_palm_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Langchain::LLM::GooglePalm do
       end
 
       it "returns a message" do
-        expect(subject.chat(prompt: completion).to_s).to eq("I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?")
+        expect(subject.chat(prompt: completion)).to eq("I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?")
       end
 
       context "with custom default_options" do
@@ -142,10 +142,10 @@ RSpec.describe Langchain::LLM::GooglePalm do
       it "returns a message" do
         expect(
           subject.chat(messages: [
-            Langchain::Conversation::Prompt.new(completion),
-            Langchain::Conversation::Response.new("I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?"),
-            Langchain::Conversation::Prompt.new("I'm doing great. What are you up to?")
-          ]).to_s
+            {role: "user", content: completion},
+            {role: "assistant", content: "I am doing well, thank you for asking! I am excited to be able to help people with their tasks and to learn more about the world. How are you doing today?"},
+            {role: "user", content: "I'm doing great. What are you up to?"}
+          ])
         ).to eq("I am currently working on a project to help people with their tasks. I am also learning more about the world and how to interact with people. I am excited to be able to help people and to learn more about the world.\r\n\r\nWhat are you up to today?")
       end
     end

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -249,45 +249,45 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with prompt" do
       it "sends prompt within messages" do
-        expect(subject.chat(prompt: prompt).to_s).to eq(answer)
+        expect(subject.chat(prompt: prompt)).to eq(answer)
       end
     end
 
     context "with messages" do
       it "sends messages" do
-        expect(subject.chat(messages: [Langchain::Conversation::Prompt.new(prompt)]).to_s).to eq(answer)
+        expect(subject.chat(messages: [{role: "user", content: prompt}])).to eq(answer)
       end
     end
 
     context "with context" do
-      let(:context) { Langchain::Conversation::Context.new("You are a chatbot") }
+      let(:context) { "You are a chatbot" }
       let(:history) do
         [
-          {role: "system", content: context.to_s},
+          {role: "system", content: context},
           {role: "user", content: prompt}
         ]
       end
 
       it "sends context and prompt as messages" do
-        expect(subject.chat(prompt: prompt, context: context).to_s).to eq(answer)
+        expect(subject.chat(prompt: prompt, context: context)).to eq(answer)
       end
 
       it "sends context and messages as joint messages" do
-        expect(subject.chat(messages: [Langchain::Conversation::Prompt.new(prompt)], context: context).to_s).to eq(answer)
+        expect(subject.chat(messages: [{role: "user", content: prompt}], context: context)).to eq(answer)
       end
     end
 
     context "with context and examples" do
-      let(:context) { Langchain::Conversation::Context.new("You are a chatbot") }
+      let(:context) { "You are a chatbot" }
       let(:examples) do
         [
-          Langchain::Conversation::Prompt.new("Hello"),
-          Langchain::Conversation::Response.new("Hi. How can I assist you today?")
+          {role: "user", content: "Hello"},
+          {role: "assistant", content: "Hi. How can I assist you today?"}
         ]
       end
       let(:history) do
         [
-          {role: "system", content: context.to_s},
+          {role: "system", content: context},
           {role: "user", content: "Hello"},
           {role: "assistant", content: "Hi. How can I assist you today?"},
           {role: "user", content: prompt}
@@ -295,23 +295,23 @@ RSpec.describe Langchain::LLM::OpenAI do
       end
 
       it "sends context, prompt and examples as joint messages" do
-        expect(subject.chat(prompt: prompt, context: context, examples: examples).to_s).to eq(answer)
+        expect(subject.chat(prompt: prompt, context: context, examples: examples)).to eq(answer)
       end
 
       it "sends context, messages and examples as joint messages" do
-        expect(subject.chat(messages: [Langchain::Conversation::Prompt.new(prompt)], context: context, examples: examples).to_s).to eq(answer)
+        expect(subject.chat(messages: [{role: "user", content: prompt}], context: context, examples: examples).to_s).to eq(answer)
       end
 
       context "with prompt, messages, context and examples" do
         let(:messages) do
           [
-            Langchain::Conversation::Prompt.new("Can you answer questions?"),
-            Langchain::Conversation::Response.new("Yes, I can answer questions.")
+            {role: "user", content: "Can you answer questions?"},
+            {role: "assistant", content: "Yes, I can answer questions."}
           ]
         end
         let(:history) do
           [
-            {role: "system", content: context.to_s},
+            {role: "system", content: context},
             {role: "user", content: "Hello"},
             {role: "assistant", content: "Hi. How can I assist you today?"},
             {role: "user", content: "Can you answer questions?"},
@@ -321,17 +321,17 @@ RSpec.describe Langchain::LLM::OpenAI do
         end
 
         it "sends context, prompt, messages and examples as joint messages" do
-          expect(subject.chat(prompt: prompt, messages: messages, context: context, examples: examples).to_s).to eq(answer)
+          expect(subject.chat(prompt: prompt, messages: messages, context: context, examples: examples)).to eq(answer)
         end
       end
 
       context "when context is already present in messages" do
         let(:messages) do
           [
-            Langchain::Conversation::Context.new(context),
-            Langchain::Conversation::Prompt.new("Hello"),
-            Langchain::Conversation::Response.new("Hi. How can I assist you today?"),
-            Langchain::Conversation::Prompt.new(prompt)
+            {role: "system", content: context},
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi. How can I assist you today?"},
+            {role: "user", content: prompt}
           ]
         end
         let(:history) do
@@ -344,22 +344,22 @@ RSpec.describe Langchain::LLM::OpenAI do
         end
 
         it "it overrides system message with context" do
-          expect(subject.chat(messages: messages, context: Langchain::Conversation::Context.new("You are a human being")).to_s).to eq(answer)
+          expect(subject.chat(messages: messages, context: "You are a human being")).to eq(answer)
         end
       end
 
       context "when last message is from user and prompt is present" do
         let(:messages) do
           [
-            context,
-            Langchain::Conversation::Prompt.new("Hello"),
-            Langchain::Conversation::Response.new("Hi. How can I assist you today?"),
-            Langchain::Conversation::Prompt.new("I want to ask a question")
+            {role: "system", content: context},
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi. How can I assist you today?"},
+            {role: "user", content: "I want to ask a question"}
           ]
         end
         let(:history) do
           [
-            {role: "system", content: context.to_s},
+            {role: "system", content: context},
             {role: "user", content: "Hello"},
             {role: "assistant", content: "Hi. How can I assist you today?"},
             {role: "user", content: "I want to ask a question\n#{prompt}"}
@@ -367,7 +367,7 @@ RSpec.describe Langchain::LLM::OpenAI do
         end
 
         it "it combines last message and prompt" do
-          expect(subject.chat(prompt: prompt, messages: messages).to_s).to eq(answer)
+          expect(subject.chat(prompt: prompt, messages: messages)).to eq(answer)
         end
       end
     end
@@ -377,7 +377,7 @@ RSpec.describe Langchain::LLM::OpenAI do
       let(:model) { "gpt-3.5-turbo-0301" }
 
       it "sends prompt as message and additional params and returns a response message" do
-        expect(subject.chat(prompt: prompt, model: model, temperature: temperature).to_s).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
+        expect(subject.chat(prompt: prompt, model: model, temperature: temperature)).to eq(answer)
       end
 
       context "functions" do
@@ -385,7 +385,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
         it "functions will be passed on options as accessor" do
           subject.functions = [{foo: :bar}]
-          expect(subject.chat(prompt: prompt, model: model, temperature: temperature)).to be_a Langchain::Conversation::Response
+          expect(subject.chat(prompt: prompt, model: model, temperature: temperature)).to eq(answer)
         end
       end
     end


### PR DESCRIPTION
## Motivation
LLM classes are a low-level API for working with large language models. Classes like `LLM::OpenAI` and `LLM::GooglePalm` should allow users to work with simple data structures like `String` and `Has` and not enforce wrapping data into a higher-level classes like `AIMessage`, `HumanMessage`, etc. And its methods should not return instances of those classes.

## Changes
- Update `chat` method on LLM classes to accept `string` and returning `string` as a result
- Update tests 