### PR TITLE
👷‍♂️ Conversations: Allow OpenAI LLM to return multiple choices [Part 3]

### DIFF
--- a/lib/langchain/conversation/message.rb
+++ b/lib/langchain/conversation/message.rb
@@ -3,7 +3,7 @@
 module Langchain
   class Conversation
     class Message
-      attr_reader :content, :additional_kwargs
+      attr_reader :content
 
       ROLE_MAPPING = {
         context: "system",
@@ -11,9 +11,8 @@ module Langchain
         response: "assistant"
       }
 
-      def initialize(content, additional_kwargs = nil)
+      def initialize(content)
         @content = content
-        @additional_kwargs = additional_kwargs
       end
 
       def role
@@ -36,11 +35,7 @@ module Langchain
       end
 
       def to_json(options = {})
-        hash = to_h
-
-        hash[:additional_kwargs] = additional_kwargs unless additional_kwargs.nil? || additional_kwargs.empty?
-
-        hash.to_json
+        to_h.to_json
       end
 
       private

--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -11,6 +11,7 @@ module Langchain::LLM
   #
   class OpenAI < Base
     DEFAULTS = {
+      n: 1,
       temperature: 0.0,
       completion_model_name: "gpt-3.5-turbo",
       chat_completion_model_name: "gpt-3.5-turbo",
@@ -118,13 +119,13 @@ module Langchain::LLM
     # @param context [String] An initial context to provide as a system message, ie "You are RubyGPT, a helpful chat bot for helping people learn Ruby"
     # @param examples [Array<Hash>] Examples of messages to provide to the model. Useful for Few-Shot Prompting
     # @param options [Hash] extra parameters passed to OpenAI::Client#chat
-    # @yield [Hash] Stream responses back one String at a time
-    # @return [Hash] The chat completion
+    # @yield [Hash] Stream responses back one token at a time
+    # @return [String|Array<String>] The chat completion
     #
-    def chat(prompt: "", messages: [], context: "", examples: [], **options)
+    def chat(prompt: "", messages: [], context: "", examples: [], **options, &block)
       raise ArgumentError.new(":prompt or :messages argument is expected") if prompt.empty? && messages.empty?
 
-      parameters = compose_parameters @defaults[:chat_completion_model_name], options
+      parameters = compose_parameters @defaults[:chat_completion_model_name], options, &block
       parameters[:messages] = compose_chat_messages(prompt: prompt, messages: messages, context: context, examples: examples)
 
       if functions
@@ -133,17 +134,11 @@ module Langchain::LLM
         parameters[:max_tokens] = validate_max_tokens(parameters[:messages], parameters[:model])
       end
 
-      if (streaming = block_given?)
-        parameters[:stream] = proc do |chunk, _bytesize|
-          yield chunk.dig("choices", 0, "delta")
-        end
-      end
-
       response = with_api_error_handling { client.chat(parameters: parameters) }
 
-      return if streaming
+      return if block
 
-      response.dig("choices", 0, "message", "content")
+      extract_response response
     end
 
     #
@@ -179,12 +174,18 @@ module Langchain::LLM
       response.dig("choices", 0, "text")
     end
 
-    def compose_parameters(model, params)
-      default_params = {model: model, temperature: @defaults[:temperature]}
-
+    def compose_parameters(model, params, &block)
+      default_params = {model: model, temperature: @defaults[:temperature], n: @defaults[:n]}
       default_params[:stop] = params.delete(:stop_sequences) if params[:stop_sequences]
+      parameters = default_params.merge(params)
 
-      default_params.merge(params)
+      if block
+        parameters[:stream] = proc do |chunk, _bytesize|
+          yield chunk.dig("choices", 0)
+        end
+      end
+
+      parameters
     end
 
     def compose_chat_messages(prompt:, messages: [], context: "", examples: [])
@@ -221,6 +222,8 @@ module Langchain::LLM
 
     def with_api_error_handling
       response = yield
+      return if response.empty?
+
       raise Langchain::LLM::ApiError.new "OpenAI API error: #{response.dig("error", "message")}" if response&.dig("error")
 
       response
@@ -228,6 +231,11 @@ module Langchain::LLM
 
     def validate_max_tokens(messages, model)
       LENGTH_VALIDATOR.validate_max_tokens!(messages, model)
+    end
+
+    def extract_response(response)
+      results = response.dig("choices").map { |choice| choice.dig("message", "content") }
+      (results.size == 1) ? results.first : results
     end
   end
 end

--- a/spec/langchain/conversation_spec.rb
+++ b/spec/langchain/conversation_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe Langchain::Conversation do
                   {role: "user", content: prompt}
                 ],
                 model: "gpt-3.5-turbo",
+                n: 1,
                 temperature: 0.0
               }
             ).and_return(response)
@@ -283,6 +284,7 @@ RSpec.describe Langchain::Conversation do
               {role: "user", content: prompt}
             ],
             model: "gpt-3.5-turbo",
+            n: 1,
             temperature: 0.0
           }
         ).and_return(response)

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe Langchain::LLM::OpenAI do
       let(:parameters) do
         {
           parameters: {
+            n: 1,
             model: "gpt-3.5-turbo",
             messages: [{content: "Hello World", role: "user"}],
             temperature: 0.0,
@@ -123,11 +124,16 @@ RSpec.describe Langchain::LLM::OpenAI do
           )
         }
         let(:parameters) do
-          {parameters:
-            {model: "text-davinci-003",
-             prompt: "Hello World",
-             temperature: 0.0,
-             max_tokens: 4095}}
+          {
+            parameters:
+            {
+              n: 1,
+              model: "text-davinci-003",
+              prompt: "Hello World",
+              temperature: 0.0,
+              max_tokens: 4095
+            }
+          }
         end
 
         before do
@@ -137,10 +143,13 @@ RSpec.describe Langchain::LLM::OpenAI do
 
         it "passes correct options to the completions method" do
           expect(subject.client).to receive(:completions).with({
-            parameters: {max_tokens: 4095,
-                         model: "text-davinci-003",
-                         prompt: "Hello World",
-                         temperature: 0.0}
+            parameters: {
+              n: 1,
+              max_tokens: 4095,
+              model: "text-davinci-003",
+              prompt: "Hello World",
+              temperature: 0.0
+            }
           }).and_return(response)
           subject.complete(prompt: "Hello World")
         end
@@ -161,20 +170,27 @@ RSpec.describe Langchain::LLM::OpenAI do
         }
 
         let(:parameters) do
-          {parameters:
-            {model: "gpt-3.5-turbo",
-             messages: [{content: "Hello World", role: "user"}],
-             temperature: 0.0,
-             max_tokens: 4086}}
+          {
+            parameters: {
+              n: 1,
+              model: "gpt-3.5-turbo",
+              messages: [{content: "Hello World", role: "user"}],
+              temperature: 0.0,
+              max_tokens: 4086
+            }
+          }
         end
 
         it "passes correct options to the chat method" do
-          expect(subject.client).to receive(:chat).with(
-            {parameters: {max_tokens: 16374,
-                          model: "gpt-3.5-turbo-16k",
-                          messages: [{content: "Hello World", role: "user"}],
-                          temperature: 0.0}}
-          ).and_return(response)
+          expect(subject.client).to receive(:chat).with({
+            parameters: {
+              n: 1,
+              max_tokens: 16374,
+              model: "gpt-3.5-turbo-16k",
+              messages: [{content: "Hello World", role: "user"}],
+              temperature: 0.0
+            }
+          }).and_return(response)
           subject.complete(prompt: "Hello World")
         end
       end
@@ -182,7 +198,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with prompt and parameters" do
       let(:parameters) do
-        {parameters: {model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 1.0, max_tokens: 4086}}
+        {parameters: {n: 1, model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 1.0, max_tokens: 4086}}
       end
 
       it "returns a completion" do
@@ -192,7 +208,7 @@ RSpec.describe Langchain::LLM::OpenAI do
 
     context "with failed API call" do
       let(:parameters) do
-        {parameters: {model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 0.0, max_tokens: 4086}}
+        {parameters: {n: 1, model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 0.0, max_tokens: 4086}}
       end
       let(:response) do
         {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
@@ -216,9 +232,23 @@ RSpec.describe Langchain::LLM::OpenAI do
     let(:prompt) { "What is the meaning of life?" }
     let(:model) { "gpt-3.5-turbo" }
     let(:temperature) { 0.0 }
+    let(:n) { 1 }
     let(:history) { [content: prompt, role: "user"] }
-    let(:parameters) { {parameters: {messages: history, model: model, temperature: temperature, max_tokens: be_between(4014, 4096)}} }
+    let(:parameters) { {parameters: {n: n, messages: history, model: model, temperature: temperature, max_tokens: be_between(4014, 4096)}} }
     let(:answer) { "As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?" }
+    let(:answer_2) { "Alternative answer" }
+    let(:choices) do
+      [
+        {
+          "message" => {
+            "role" => "assistant",
+            "content" => answer
+          },
+          "finish_reason" => "stop",
+          "index" => 0
+        }
+      ]
+    end
     let(:response) do
       {
         "id" => "chatcmpl-7Hcl1sXOtsaUBKJGGhNujEIwhauaD",
@@ -230,16 +260,7 @@ RSpec.describe Langchain::LLM::OpenAI do
           "completion_tokens" => 25,
           "total_tokens" => 39
         },
-        "choices" => [
-          {
-            "message" => {
-              "role" => "assistant",
-              "content" => answer
-            },
-            "finish_reason" => "stop",
-            "index" => 0
-          }
-        ]
+        "choices" => choices
       }
     end
 
@@ -380,8 +401,30 @@ RSpec.describe Langchain::LLM::OpenAI do
         expect(subject.chat(prompt: prompt, model: model, temperature: temperature)).to eq(answer)
       end
 
+      context "with multiple choices" do
+        let(:n) { 2 }
+        let(:choices) do
+          [
+            {
+              "message" => {"role" => "assistant", "content" => answer},
+              "finish_reason" => "stop",
+              "index" => 0
+            },
+            {
+              "message" => {"role" => "assistant", "content" => answer_2},
+              "finish_reason" => "stop",
+              "index" => 1
+            }
+          ]
+        end
+
+        it "returns multiple response messages" do
+          expect(subject.chat(prompt: prompt, model: model, temperature: temperature, n: 2)).to eq([answer, answer_2])
+        end
+      end
+
       context "functions" do
-        let(:parameters) { {parameters: {messages: history, model: model, temperature: temperature, functions: [{foo: :bar}]}} }
+        let(:parameters) { {parameters: {n: 1, messages: history, model: model, temperature: temperature, functions: [{foo: :bar}]}} }
 
         it "functions will be passed on options as accessor" do
           subject.functions = [{foo: :bar}]


### PR DESCRIPTION
## Motivation
Previously we had `response.dig("choices", 0, "message")` hardcoded in our `LLM::OpenAI#chat` method. Which means that we don't support multiple-choice responses and always return only the first choice. The number of choices is controlled by `n` parameter that can be passed to `initializer` as default options or to the `chat` method.

## Changes
- Change the `chat` method to return either a string (in case of a single choice) or an array of strings (in case of multiple choices)
- If a block is given to handle streaming response the entire hash is yielded to the block as it contains an `index` of a choice as well as `delta`.
- Update specs to account for the default `n` param that is sent to open ai API.
