### PR TITLE
Remove $ from shell commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Langchain.rb is a library that's an abstraction layer on top many emergent AI, M
 
 Install the gem and add to the application's Gemfile by executing:
 
-    $ bundle add langchainrb
+    bundle add langchainrb
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
-    $ gem install langchainrb
+    gem install langchainrb
 
 ## Usage
 


### PR DESCRIPTION
While the `$` makes it clearer it should be run from the terminal, you can't actually copy & paste w/the GitHub copy button as it includes the $.

Maybe it's better to make the tradeoff and drop the `$` as most Rails devs will realize those should be run in the terminal?

![image](https://github.com/andreibondarev/langchainrb/assets/7880/51a2b2cf-015a-43f9-8aea-6fcdc1e5fd8c)
