### PR TITLE
Chroma DB - add metadata support

### DIFF
--- a/lib/langchain/vectorsearch/chroma.rb
+++ b/lib/langchain/vectorsearch/chroma.rb
@@ -29,14 +29,15 @@ module Langchain::Vectorsearch
 
     # Add a list of texts to the index
     # @param texts [Array<String>] The list of texts to add
+    # @param ids [Array<String>] The list of ids to use for the texts (optional)
+    # @param metadatas [Array<Hash>] The list of metadata to use for the texts (optional)
     # @return [Hash] The response from the server
-    def add_texts(texts:, ids: [])
+    def add_texts(texts:, ids: [], metadatas: [])
       embeddings = Array(texts).map.with_index do |text, i|
         ::Chroma::Resources::Embedding.new(
           id: ids[i] ? ids[i].to_s : SecureRandom.uuid,
           embedding: llm.embed(text: text).embedding,
-          # TODO: Add support for passing metadata
-          metadata: {}, # metadatas[index],
+          metadata: metadatas[i] ? metadatas[i] : {},
           document: text # Do we actually need to store the whole original document?
         )
       end
@@ -45,13 +46,12 @@ module Langchain::Vectorsearch
       collection.add(embeddings)
     end
 
-    def update_texts(texts:, ids:)
+    def update_texts(texts:, ids:, metadatas: [])
       embeddings = Array(texts).map.with_index do |text, i|
         ::Chroma::Resources::Embedding.new(
           id: ids[i].to_s,
           embedding: llm.embed(text: text).embedding,
-          # TODO: Add support for passing metadata
-          metadata: [], # metadatas[index],
+          metadata: metadatas[i] ? metadatas[i] : {},
           document: text # Do we actually need to store the whole original document?
         )
       end

--- a/spec/langchain/vectorsearch/chroma_spec.rb
+++ b/spec/langchain/vectorsearch/chroma_spec.rb
@@ -46,11 +46,17 @@ RSpec.describe Langchain::Vectorsearch::Chroma do
   let(:embedding) { [0.1, 0.2, 0.3] }
   let(:count) { 1 }
   let(:query) { "Greetings Earth" }
+  let(:metadata) do
+    {
+      "foo" => "bar",
+      "meaningful" => "data"
+    }
+  end
   let(:results) {
     Array(Chroma::Resources::Embedding.new(
       id: SecureRandom.uuid,
       document: text,
-      metadata: nil,
+      metadata: metadata,
       embedding: nil,
       distance: 0.5068268179893494
     ))
@@ -71,6 +77,12 @@ RSpec.describe Langchain::Vectorsearch::Chroma do
         expect(subject.add_texts(texts: [text], ids: ["123"])).to eq(true)
       end
     end
+
+    context "when metadatas are provided" do
+      it "adds texts" do
+        expect(subject.add_texts(texts: [text], ids: ["123"], metadatas: [metadata])).to eq(true)
+      end
+    end
   end
 
   describe "update_texts" do
@@ -81,6 +93,12 @@ RSpec.describe Langchain::Vectorsearch::Chroma do
 
     it "updates texts" do
       expect(subject.update_texts(texts: [text], ids: [1])).to eq(true)
+    end
+
+    context "when metadatas are provided" do
+      it "updates texts" do
+        expect(subject.update_texts(texts: [text], ids: [1], metadatas: [metadata])).to eq(true)
+      end
     end
   end
 


### PR DESCRIPTION
updated `add_texts` and `update_texts` to accept an array of hashes to be stored with the embeddings

```Ruby
subject.add_texts(
  texts: ["Rotjaw is the first Wild Target boss in Hunt: Showdown."], 
  ids: ["1"], 
  metadatas: [{ game: "Hunt: Showdown", boss: "Rotjaw" }]
)
```