### PR TITLE
Change zeitwerk version to ~> 2.5 from explicit = version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
       json-schema (~> 4.0.0)
       pragmatic_segmenter (~> 0.3.0)
       tiktoken_ruby (~> 0.0.5)
-      zeitwerk (= 2.6.11)
+      zeitwerk (~> 2.5)
 
 GEM
   remote: https://rubygems.org/

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "colorize", "~> 0.8.1"
   spec.add_dependency "tiktoken_ruby", "~> 0.0.5"
   spec.add_dependency "json-schema", "~> 4.0.0"
-  spec.add_dependency "zeitwerk", "2.6.11"
+  spec.add_dependency "zeitwerk", "~> 2.5"
   spec.add_dependency "pragmatic_segmenter", "~> 0.3.0"
 
   # development dependencies


### PR DESCRIPTION
👋 @santib @andreibondarev - noticed while adding the gem with a Rails 7.0 app, that it auto-resolved an earlier version (0.6.11) - i.e. related to https://github.com/andreibondarev/langchainrb/pull/278

railties on the 7.0 version uses ~> 2.5 so it doesn't allow latest langchainrb and Rails 7.0 to co-exist; there doesn't seem to be an explicit reason for 2.6.11 so allowing an earlier version here.

https://github.com/rails/rails/blob/v7.0.8/railties/railties.gemspec#L46