### PR TITLE
Add support for OpenAI via Azure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
     eqn (1.6.5)
       treetop (>= 1.2.0)
     erubi (1.12.0)
+    event_stream_parser (0.3.0)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -273,7 +274,8 @@ GEM
     ruby-next-core (0.15.3)
     ruby-next-parser (3.1.1.3)
       parser (>= 3.0.3.1)
-    ruby-openai (4.1.0)
+    ruby-openai (5.2.0)
+      event_stream_parser (>= 0.3.0, < 1.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
@@ -360,7 +362,7 @@ DEPENDENCIES
   roo (~> 2.10.0)
   rspec (~> 3.0)
   rubocop
-  ruby-openai (~> 4.1.0)
+  ruby-openai (~> 5.2.0)
   safe_ruby (~> 1.0.4)
   sequel (~> 5.68.0)
   standardrb

--- a/README.md
+++ b/README.md
@@ -197,6 +197,42 @@ qdrant:
 client.llm.functions = functions
 ```
 
+#### Azure
+Add `gem "ruby-openai", "~> 4.0.0"` to your Gemfile.
+
+```ruby
+azure = Langchain::LLM::Azure.new(
+  api_key: ENV["AZURE_API_KEY"],
+  llm_options: {
+    api_type: :azure,
+    api_version: "2023-03-15-preview"
+  },
+  embedding_deployment_url: ENV.fetch("AZURE_EMBEDDING_URI"),
+  chat_deployment_url: ENV.fetch("AZURE_CHAT_URI")
+)
+```
+where `AZURE_EMBEDDING_URI` is e.g. `https://custom-domain.openai.azure.com/openai/deployments/gpt-35-turbo` and `AZURE_CHAT_URI` is e.g. `https://custom-domain.openai.azure.com/openai/deployments/ada-2`
+
+You can pass additional parameters to the constructor, it will be passed to the Azure client:
+```ruby
+azure = Langchain::LLM::Azure.new(
+  api_key: ENV["AZURE_API_KEY"],
+  llm_options: {
+    api_type: :azure,
+    api_version: "2023-03-15-preview",
+    request_timeout: 240 # Optional
+  },
+  embedding_deployment_url: ENV.fetch("AZURE_EMBEDDING_URI"),
+  chat_deployment_url: ENV.fetch("AZURE_CHAT_URI")
+)
+```
+```ruby
+azure.embed(text: "foo bar")
+```
+```ruby
+azure.complete(prompt: "What is the meaning of life?")
+```
+
 #### Cohere
 Add `gem "cohere-ruby", "~> 0.9.6"` to your Gemfile.
 
@@ -348,7 +384,7 @@ prompt = Langchain::Prompt.load_from_path(file_path: "spec/fixtures/prompt/promp
 prompt.input_variables #=> ["adjective", "content"]
 ```
 
-### Using Output Parsers 
+### Using Output Parsers
 
 Parse LLM text responses into structured output, such as JSON.
 
@@ -547,7 +583,7 @@ Ragas helps you evaluate your Retrieval Augmented Generation (RAG) pipelines. Th
 
 ```ruby
 # We recommend using Langchain::LLM::OpenAI as your llm for Ragas
-ragas = Langchain::Evals::Ragas::Main.new(llm: llm) 
+ragas = Langchain::Evals::Ragas::Main.new(llm: llm)
 
 # The answer that the LLM generated
 # The question (or the original prompt) that was asked

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ client.llm.functions = functions
 ```
 
 #### Azure
-Add `gem "ruby-openai", "~> 4.0.0"` to your Gemfile.
+Add `gem "ruby-openai", "~> 5.2.0"` to your Gemfile.
 
 ```ruby
 azure = Langchain::LLM::Azure.new(

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "replicate-ruby", "~> 0.2.2"
   spec.add_development_dependency "qdrant-ruby", "~> 0.9.4"
   spec.add_development_dependency "roo", "~> 2.10.0"
-  spec.add_development_dependency "ruby-openai", "~> 4.1.0"
+  spec.add_development_dependency "ruby-openai", "~> 5.2.0"
   spec.add_development_dependency "safe_ruby", "~> 1.0.4"
   spec.add_development_dependency "sequel", "~> 5.68.0"
   spec.add_development_dependency "weaviate-ruby", "~> 0.8.9"

--- a/lib/langchain/llm/azure.rb
+++ b/lib/langchain/llm/azure.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Langchain::LLM
-  # LLM interface for OpenAI APIs: https://platform.openai.com/overview
+  # LLM interface for Azure OpenAI Service APIs: https://learn.microsoft.com/en-us/azure/ai-services/openai/
   #
   # Gem requirements:
   #    gem "ruby-openai", "~> 4.0.0"

--- a/lib/langchain/llm/azure.rb
+++ b/lib/langchain/llm/azure.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+module Langchain::LLM
+  # LLM interface for OpenAI APIs: https://platform.openai.com/overview
+  #
+  # Gem requirements:
+  #    gem "ruby-openai", "~> 4.0.0"
+  #
+  # Usage:
+  #    openai = Langchain::LLM::Azure.new(api_key:, llm_options: {}, embedding_deployment_url: chat_deployment_url:)
+  #
+  class Azure < OpenAI
+    attr_reader :embed_client
+    attr_reader :chat_client
+
+    def initialize(
+      api_key:,
+      llm_options: {},
+      default_options: {},
+      embedding_deployment_url: nil,
+      chat_deployment_url: nil
+    )
+      depends_on "ruby-openai", req: "openai"
+
+      @embed_client = ::OpenAI::Client.new(
+        access_token: api_key,
+        uri_base: embedding_deployment_url,
+        **llm_options
+      )
+      @chat_client = ::OpenAI::Client.new(
+        access_token: api_key,
+        uri_base: chat_deployment_url,
+        **llm_options
+      )
+      @defaults = DEFAULTS.merge(default_options)
+    end
+
+    #
+    # Generate an embedding for a given text
+    #
+    # @param text [String] The text to generate an embedding for
+    # @param params extra parameters passed to OpenAI::Client#embeddings
+    # @return [Langchain::LLM::OpenAIResponse] Response object
+    #
+    def embed(text:, **params)
+      parameters = {model: @defaults[:embeddings_model_name], input: text}
+
+      validate_max_tokens(text, parameters[:model])
+
+      response = with_api_error_handling do
+        embed_client.embeddings(parameters: parameters.merge(params))
+      end
+
+      Langchain::LLM::OpenAIResponse.new(response)
+    end
+
+    #
+    # Generate a completion for a given prompt
+    #
+    # @param prompt [String] The prompt to generate a completion for
+    # @param params  extra parameters passed to OpenAI::Client#complete
+    # @return [Langchain::LLM::Response::OpenaAI] Response object
+    #
+    def complete(prompt:, **params)
+      parameters = compose_parameters @defaults[:completion_model_name], params
+
+      parameters[:messages] = compose_chat_messages(prompt: prompt)
+      parameters[:max_tokens] = validate_max_tokens(parameters[:messages], parameters[:model])
+
+      response = with_api_error_handling do
+        chat_client.chat(parameters: parameters)
+      end
+
+      Langchain::LLM::OpenAIResponse.new(response)
+    end
+
+    #
+    # Generate a chat completion for a given prompt or messages.
+    #
+    # == Examples
+    #
+    #     # simplest case, just give a prompt
+    #     openai.chat prompt: "When was Ruby first released?"
+    #
+    #     # prompt plus some context about how to respond
+    #     openai.chat context: "You are RubyGPT, a helpful chat bot for helping people learn Ruby", prompt: "Does Ruby have a REPL like IPython?"
+    #
+    #     # full control over messages that get sent, equivilent to the above
+    #     openai.chat messages: [
+    #       {
+    #         role: "system",
+    #         content: "You are RubyGPT, a helpful chat bot for helping people learn Ruby", prompt: "Does Ruby have a REPL like IPython?"
+    #       },
+    #       {
+    #         role: "user",
+    #         content: "When was Ruby first released?"
+    #       }
+    #     ]
+    #
+    #     # few-short prompting with examples
+    #     openai.chat prompt: "When was factory_bot released?",
+    #       examples: [
+    #         {
+    #           role: "user",
+    #           content: "When was Ruby on Rails released?"
+    #         }
+    #         {
+    #           role: "assistant",
+    #           content: "2004"
+    #         },
+    #       ]
+    #
+    # @param prompt [String] The prompt to generate a chat completion for
+    # @param messages [Array<Hash>] The messages that have been sent in the conversation
+    # @param context [String] An initial context to provide as a system message, ie "You are RubyGPT, a helpful chat bot for helping people learn Ruby"
+    # @param examples [Array<Hash>] Examples of messages to provide to the model. Useful for Few-Shot Prompting
+    # @param options [Hash] extra parameters passed to OpenAI::Client#chat
+    # @yield [Hash] Stream responses back one token at a time
+    # @return [Langchain::LLM::OpenAIResponse] Response object
+    #
+    def chat(prompt: "", messages: [], context: "", examples: [], **options, &block)
+      raise ArgumentError.new(":prompt or :messages argument is expected") if prompt.empty? && messages.empty?
+
+      parameters = compose_parameters @defaults[:chat_completion_model_name], options, &block
+      parameters[:messages] = compose_chat_messages(prompt: prompt, messages: messages, context: context, examples: examples)
+
+      if functions
+        parameters[:functions] = functions
+      else
+        parameters[:max_tokens] = validate_max_tokens(parameters[:messages], parameters[:model])
+      end
+
+      response = with_api_error_handling { chat_client.chat(parameters: parameters) }
+
+      return if block
+
+      Langchain::LLM::OpenAIResponse.new(response)
+    end
+  end
+end

--- a/lib/langchain/llm/azure.rb
+++ b/lib/langchain/llm/azure.rb
@@ -21,7 +21,6 @@ module Langchain::LLM
       chat_deployment_url: nil
     )
       depends_on "ruby-openai", req: "openai"
-
       @embed_client = ::OpenAI::Client.new(
         access_token: api_key,
         uri_base: embedding_deployment_url,

--- a/lib/langchain/llm/azure.rb
+++ b/lib/langchain/llm/azure.rb
@@ -4,7 +4,7 @@ module Langchain::LLM
   # LLM interface for Azure OpenAI Service APIs: https://learn.microsoft.com/en-us/azure/ai-services/openai/
   #
   # Gem requirements:
-  #    gem "ruby-openai", "~> 4.0.0"
+  #    gem "ruby-openai", "~> 5.2.0"
   #
   # Usage:
   #    openai = Langchain::LLM::Azure.new(api_key:, llm_options: {}, embedding_deployment_url: chat_deployment_url:)

--- a/lib/langchain/llm/base.rb
+++ b/lib/langchain/llm/base.rb
@@ -8,6 +8,7 @@ module Langchain::LLM
   # Langchain.rb provides a common interface to interact with all supported LLMs:
   #
   # - {Langchain::LLM::AI21}
+  # - {Langchain::LLM::Azure}
   # - {Langchain::LLM::Cohere}
   # - {Langchain::LLM::GooglePalm}
   # - {Langchain::LLM::HuggingFace}

--- a/spec/langchain/llm/azure_spec.rb
+++ b/spec/langchain/llm/azure_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Langchain::LLM::Azure do
     described_class.new(
       api_key: "123",
       embedding_deployment_url: "http://localhost:1234/deployments/embedding",
-      chat_deployment_url: "http://localhost:1234/deployments/chat")
+      chat_deployment_url: "http://localhost:1234/deployments/chat"
+    )
   end
 
   describe "#initialize" do
@@ -16,7 +17,14 @@ RSpec.describe Langchain::LLM::Azure do
     end
 
     context "when llm_options are passed" do
-      let(:subject) { described_class.new(api_key: "123", llm_options: {api_type: :azure}) }
+      let(:subject) do
+        described_class.new(
+          api_key: "123",
+          llm_options: {api_type: :azure},
+          embedding_deployment_url: "http://localhost:1234/deployments/embedding",
+          chat_deployment_url: "http://localhost:1234/deployments/chat"
+        )
+      end
 
       it "initializes the client without any errors" do
         expect { subject }.not_to raise_error
@@ -24,8 +32,9 @@ RSpec.describe Langchain::LLM::Azure do
 
       it "passes correct options to the client" do
         # openai-ruby sets global configuration options here: https://github.com/alexrudall/ruby-openai/blob/main/lib/openai/client.rb
-        subject
-        expect(OpenAI.configuration.api_type).to eq(:azure)
+        result = subject
+        expect(result.embed_client.api_type).to eq(:azure)
+        expect(result.chat_client.api_type).to eq(:azure)
       end
     end
   end
@@ -91,451 +100,427 @@ RSpec.describe Langchain::LLM::Azure do
     end
   end
 
-  # describe "#complete" do
-  #   let(:response) do
-  #     {
-  #       "id" => "cmpl-7BZg4cP5xzga4IyLI6u97WMepAJj2",
-  #       "object" => "chat.completion",
-  #       "created" => 1682993108,
-  #       "model" => "gpt-3.5-turbo",
-  #       "choices" => [
-  #         {
-  #           "message" => {
-  #             "role" => "assistant",
-  #             "content" => "The meaning of life is subjective and can vary from person to person."
-  #           },
-  #           "finish_reason" => "stop",
-  #           "index" => 0
-  #         }
-  #       ],
-  #       "usage" => {
-  #         "prompt_tokens" => 7,
-  #         "completion_tokens" => 16,
-  #         "total_tokens" => 23
-  #       }
-  #     }
-  #   end
+  describe "#complete" do
+    let(:response) do
+      {
+        "id" => "cmpl-7BZg4cP5xzga4IyLI6u97WMepAJj2",
+        "object" => "chat.completion",
+        "created" => 1682993108,
+        "model" => "gpt-3.5-turbo",
+        "choices" => [
+          {
+            "message" => {
+              "role" => "assistant",
+              "content" => "The meaning of life is subjective and can vary from person to person."
+            },
+            "finish_reason" => "stop",
+            "index" => 0
+          }
+        ],
+        "usage" => {
+          "prompt_tokens" => 7,
+          "completion_tokens" => 16,
+          "total_tokens" => 23
+        }
+      }
+    end
 
-  #   before do
-  #     allow(subject.client).to receive(:chat).with(parameters).and_return(response)
-  #     allow(subject.client).to receive(:completions).with(parameters).and_return(response)
-  #   end
+    before do
+      allow(subject.chat_client).to receive(:chat).with(parameters).and_return(response)
+      allow(subject.chat_client).to receive(:completions).with(parameters).and_return(response)
+    end
 
-  #   context "with default parameters" do
-  #     let(:parameters) do
-  #       {
-  #         parameters: {
-  #           n: 1,
-  #           model: "gpt-3.5-turbo",
-  #           messages: [{content: "Hello World", role: "user"}],
-  #           temperature: 0.0,
-  #           max_tokens: 4086
-  #         }
-  #       }
-  #     end
+    context "with default parameters" do
+      let(:parameters) do
+        {
+          parameters: {
+            n: 1,
+            model: "gpt-3.5-turbo",
+            messages: [{content: "Hello World", role: "user"}],
+            temperature: 0.0,
+            max_tokens: 4086
+          }
+        }
+      end
 
-  #     it "returns valid llm response object" do
-  #       response = subject.complete(prompt: "Hello World")
+      it "returns valid llm response object" do
+        response = subject.complete(prompt: "Hello World")
 
-  #       expect(response).to be_a(Langchain::LLM::OpenAIResponse)
-  #       expect(response.model).to eq("gpt-3.5-turbo")
-  #       expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
-  #       expect(response.prompt_tokens).to eq(7)
-  #       expect(response.completion_tokens).to eq(16)
-  #       expect(response.total_tokens).to eq(23)
-  #     end
+        expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+        expect(response.model).to eq("gpt-3.5-turbo")
+        expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
+        expect(response.prompt_tokens).to eq(7)
+        expect(response.completion_tokens).to eq(16)
+        expect(response.total_tokens).to eq(23)
+      end
 
-  #     it "returns a completion" do
-  #       response = subject.complete(prompt: "Hello World")
+      it "returns a completion" do
+        response = subject.complete(prompt: "Hello World")
 
-  #       expect(response).to be_a(Langchain::LLM::OpenAIResponse)
-  #       expect(response.model).to eq("gpt-3.5-turbo")
-  #       expect(response.completions).to eq([{"message" => {"role" => "assistant", "content" => "The meaning of life is subjective and can vary from person to person."}, "finish_reason" => "stop", "index" => 0}])
-  #       expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
-  #     end
-  #   end
+        expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+        expect(response.model).to eq("gpt-3.5-turbo")
+        expect(response.completions).to eq([{"message" => {"role" => "assistant", "content" => "The meaning of life is subjective and can vary from person to person."}, "finish_reason" => "stop", "index" => 0}])
+        expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
+      end
+    end
 
-  #   context "with custom default_options" do
-  #     context "with legacy model" do
-  #       let(:logger) { double("logger") }
-  #       let(:subject) {
-  #         described_class.new(
-  #           api_key: "123",
-  #           default_options: {completion_model_name: "text-davinci-003"}
-  #         )
-  #       }
-  #       let(:parameters) do
-  #         {
-  #           parameters:
-  #           {
-  #             n: 1,
-  #             model: "text-davinci-003",
-  #             prompt: "Hello World",
-  #             temperature: 0.0,
-  #             max_tokens: 4095
-  #           }
-  #         }
-  #       end
+    context "with custom default_options" do
+      context "with legacy model" do
+        let(:logger) { double("logger") }
+        let(:subject) {
+          described_class.new(
+            api_key: "123",
+            default_options: {completion_model_name: "text-davinci-003"}
+          )
+        }
+        let(:parameters) do
+          {
+            parameters:
+            {
+              n: 1,
+              model: "text-davinci-003",
+              prompt: "Hello World",
+              temperature: 0.0,
+              max_tokens: 4095
+            }
+          }
+        end
+      end
 
-  #       before do
-  #         allow(Langchain).to receive(:logger).and_return(logger)
-  #         allow(logger).to receive(:warn)
-  #       end
+      context "with new model" do
+        let(:subject) {
+          described_class.new(
+            api_key: "123",
+            default_options: {completion_model_name: "gpt-3.5-turbo-16k"}
+          )
+        }
 
-  #       it "passes correct options to the completions method" do
-  #         expect(subject.client).to receive(:completions).with({
-  #           parameters: {
-  #             n: 1,
-  #             max_tokens: 4095,
-  #             model: "text-davinci-003",
-  #             prompt: "Hello World",
-  #             temperature: 0.0
-  #           }
-  #         }).and_return(response)
-  #         subject.complete(prompt: "Hello World")
-  #       end
+        let(:parameters) do
+          {
+            parameters: {
+              n: 1,
+              model: "gpt-3.5-turbo",
+              messages: [{content: "Hello World", role: "user"}],
+              temperature: 0.0,
+              max_tokens: 4086
+            }
+          }
+        end
 
-  #       it "logs a deprecation warning" do
-  #         expect(Langchain.logger).to receive(:warn).with("DEPRECATION WARNING: The model text-davinci-003 is deprecated. Please use gpt-3.5-turbo instead. Details: https://platform.openai.com/docs/deprecations/2023-07-06-gpt-and-embeddings")
+        it "passes correct options to the chat method" do
+          expect(subject.chat_client).to receive(:chat).with({
+            parameters: {
+              n: 1,
+              max_tokens: 16374,
+              model: "gpt-3.5-turbo-16k",
+              messages: [{content: "Hello World", role: "user"}],
+              temperature: 0.0
+            }
+          }).and_return(response)
+          subject.complete(prompt: "Hello World")
+        end
+      end
+    end
 
-  #         subject.complete(prompt: "Hello World")
-  #       end
-  #     end
+    context "with prompt and parameters" do
+      let(:parameters) do
+        {parameters: {n: 1, model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 1.0, max_tokens: 4086}}
+      end
 
-  #     context "with new model" do
-  #       let(:subject) {
-  #         described_class.new(
-  #           api_key: "123",
-  #           default_options: {completion_model_name: "gpt-3.5-turbo-16k"}
-  #         )
-  #       }
+      it "returns a completion" do
+        response = subject.complete(prompt: "Hello World", model: "gpt-3.5-turbo", temperature: 1.0)
 
-  #       let(:parameters) do
-  #         {
-  #           parameters: {
-  #             n: 1,
-  #             model: "gpt-3.5-turbo",
-  #             messages: [{content: "Hello World", role: "user"}],
-  #             temperature: 0.0,
-  #             max_tokens: 4086
-  #           }
-  #         }
-  #       end
+        expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
+      end
+    end
 
-  #       it "passes correct options to the chat method" do
-  #         expect(subject.client).to receive(:chat).with({
-  #           parameters: {
-  #             n: 1,
-  #             max_tokens: 16374,
-  #             model: "gpt-3.5-turbo-16k",
-  #             messages: [{content: "Hello World", role: "user"}],
-  #             temperature: 0.0
-  #           }
-  #         }).and_return(response)
-  #         subject.complete(prompt: "Hello World")
-  #       end
-  #     end
-  #   end
+    context "with failed API call" do
+      let(:parameters) do
+        {parameters: {n: 1, model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 0.0, max_tokens: 4086}}
+      end
+      let(:response) do
+        {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
+      end
 
-  #   context "with prompt and parameters" do
-  #     let(:parameters) do
-  #       {parameters: {n: 1, model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 1.0, max_tokens: 4086}}
-  #     end
+      it "raises an error" do
+        expect {
+          subject.complete(prompt: "Hello World")
+        }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
+      end
+    end
+  end
 
-  #     it "returns a completion" do
-  #       response = subject.complete(prompt: "Hello World", model: "gpt-3.5-turbo", temperature: 1.0)
+  describe "#default_dimension" do
+    it "returns the default dimension" do
+      expect(subject.default_dimension).to eq(1536)
+    end
+  end
 
-  #       expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
-  #     end
-  #   end
+  describe "#chat" do
+    let(:prompt) { "What is the meaning of life?" }
+    let(:model) { "gpt-3.5-turbo" }
+    let(:temperature) { 0.0 }
+    let(:n) { 1 }
+    let(:history) { [content: prompt, role: "user"] }
+    let(:parameters) { {parameters: {n: n, messages: history, model: model, temperature: temperature, max_tokens: be_between(4014, 4096)}} }
+    let(:answer) { "As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?" }
+    let(:answer_2) { "Alternative answer" }
+    let(:choices) do
+      [
+        {
+          "message" => {
+            "role" => "assistant",
+            "content" => answer
+          },
+          "finish_reason" => "stop",
+          "index" => 0
+        }
+      ]
+    end
+    let(:response) do
+      {
+        "id" => "chatcmpl-7Hcl1sXOtsaUBKJGGhNujEIwhauaD",
+        "object" => "chat.completion",
+        "created" => 1684434915,
+        "model" => model,
+        "usage" => {
+          "prompt_tokens" => 14,
+          "completion_tokens" => 25,
+          "total_tokens" => 39
+        },
+        "choices" => choices
+      }
+    end
 
-  #   context "with failed API call" do
-  #     let(:parameters) do
-  #       {parameters: {n: 1, model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 0.0, max_tokens: 4086}}
-  #     end
-  #     let(:response) do
-  #       {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
-  #     end
+    before do
+      allow(subject.chat_client).to receive(:chat).with(parameters).and_return(response)
+    end
 
-  #     it "raises an error" do
-  #       expect {
-  #         subject.complete(prompt: "Hello World")
-  #       }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
-  #     end
-  #   end
-  # end
+    it "returns valid llm response object" do
+      response = subject.chat(prompt: "What is the meaning of life?")
 
-  # describe "#default_dimension" do
-  #   it "returns the default dimension" do
-  #     expect(subject.default_dimension).to eq(1536)
-  #   end
-  # end
+      expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+      expect(response.model).to eq("gpt-3.5-turbo")
+      expect(response.chat_completion).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
+      expect(response.prompt_tokens).to eq(14)
+      expect(response.completion_tokens).to eq(25)
+      expect(response.total_tokens).to eq(39)
+    end
 
-  # describe "#chat" do
-  #   let(:prompt) { "What is the meaning of life?" }
-  #   let(:model) { "gpt-3.5-turbo" }
-  #   let(:temperature) { 0.0 }
-  #   let(:n) { 1 }
-  #   let(:history) { [content: prompt, role: "user"] }
-  #   let(:parameters) { {parameters: {n: n, messages: history, model: model, temperature: temperature, max_tokens: be_between(4014, 4096)}} }
-  #   let(:answer) { "As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?" }
-  #   let(:answer_2) { "Alternative answer" }
-  #   let(:choices) do
-  #     [
-  #       {
-  #         "message" => {
-  #           "role" => "assistant",
-  #           "content" => answer
-  #         },
-  #         "finish_reason" => "stop",
-  #         "index" => 0
-  #       }
-  #     ]
-  #   end
-  #   let(:response) do
-  #     {
-  #       "id" => "chatcmpl-7Hcl1sXOtsaUBKJGGhNujEIwhauaD",
-  #       "object" => "chat.completion",
-  #       "created" => 1684434915,
-  #       "model" => model,
-  #       "usage" => {
-  #         "prompt_tokens" => 14,
-  #         "completion_tokens" => 25,
-  #         "total_tokens" => 39
-  #       },
-  #       "choices" => choices
-  #     }
-  #   end
+    context "with prompt" do
+      it "sends prompt within messages" do
+        response = subject.chat(prompt: prompt)
 
-  #   before do
-  #     allow(subject.client).to receive(:chat).with(parameters).and_return(response)
-  #   end
+        expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+        expect(response.model).to eq(model)
+        expect(response.completions).to eq(choices)
+        expect(response.chat_completion).to eq(answer)
+      end
+    end
 
-  #   it "returns valid llm response object" do
-  #     response = subject.chat(prompt: "What is the meaning of life?")
+    context "with messages" do
+      it "sends messages" do
+        response = subject.chat(messages: [{role: "user", content: prompt}])
 
-  #     expect(response).to be_a(Langchain::LLM::OpenAIResponse)
-  #     expect(response.model).to eq("gpt-3.5-turbo")
-  #     expect(response.chat_completion).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
-  #     expect(response.prompt_tokens).to eq(14)
-  #     expect(response.completion_tokens).to eq(25)
-  #     expect(response.total_tokens).to eq(39)
-  #   end
+        expect(response.chat_completion).to eq(answer)
+      end
+    end
 
-  #   context "with prompt" do
-  #     it "sends prompt within messages" do
-  #       response = subject.chat(prompt: prompt)
+    context "with context" do
+      let(:context) { "You are a chatbot" }
+      let(:history) do
+        [
+          {role: "system", content: context},
+          {role: "user", content: prompt}
+        ]
+      end
 
-  #       expect(response).to be_a(Langchain::LLM::OpenAIResponse)
-  #       expect(response.model).to eq(model)
-  #       expect(response.completions).to eq(choices)
-  #       expect(response.chat_completion).to eq(answer)
-  #     end
-  #   end
+      it "sends context and prompt as messages" do
+        response = subject.chat(prompt: prompt, context: context)
 
-  #   context "with messages" do
-  #     it "sends messages" do
-  #       response = subject.chat(messages: [{role: "user", content: prompt}])
+        expect(response.chat_completion).to eq(answer)
+      end
 
-  #       expect(response.chat_completion).to eq(answer)
-  #     end
-  #   end
+      it "sends context and messages as joint messages" do
+        response = subject.chat(messages: [{role: "user", content: prompt}], context: context)
 
-  #   context "with context" do
-  #     let(:context) { "You are a chatbot" }
-  #     let(:history) do
-  #       [
-  #         {role: "system", content: context},
-  #         {role: "user", content: prompt}
-  #       ]
-  #     end
+        expect(response.chat_completion).to eq(answer)
+      end
+    end
 
-  #     it "sends context and prompt as messages" do
-  #       response = subject.chat(prompt: prompt, context: context)
+    context "with context and examples" do
+      let(:context) { "You are a chatbot" }
+      let(:examples) do
+        [
+          {role: "user", content: "Hello"},
+          {role: "assistant", content: "Hi. How can I assist you today?"}
+        ]
+      end
+      let(:history) do
+        [
+          {role: "system", content: context},
+          {role: "user", content: "Hello"},
+          {role: "assistant", content: "Hi. How can I assist you today?"},
+          {role: "user", content: prompt}
+        ]
+      end
 
-  #       expect(response.chat_completion).to eq(answer)
-  #     end
+      it "sends context, prompt and examples as joint messages" do
+        response = subject.chat(prompt: prompt, context: context, examples: examples)
 
-  #     it "sends context and messages as joint messages" do
-  #       response = subject.chat(messages: [{role: "user", content: prompt}], context: context)
+        expect(response.chat_completion).to eq(answer)
+      end
 
-  #       expect(response.chat_completion).to eq(answer)
-  #     end
-  #   end
+      it "sends context, messages and examples as joint messages" do
+        response = subject.chat(messages: [{role: "user", content: prompt}], context: context, examples: examples)
 
-  #   context "with context and examples" do
-  #     let(:context) { "You are a chatbot" }
-  #     let(:examples) do
-  #       [
-  #         {role: "user", content: "Hello"},
-  #         {role: "assistant", content: "Hi. How can I assist you today?"}
-  #       ]
-  #     end
-  #     let(:history) do
-  #       [
-  #         {role: "system", content: context},
-  #         {role: "user", content: "Hello"},
-  #         {role: "assistant", content: "Hi. How can I assist you today?"},
-  #         {role: "user", content: prompt}
-  #       ]
-  #     end
+        expect(response.chat_completion).to eq(answer)
+      end
 
-  #     it "sends context, prompt and examples as joint messages" do
-  #       response = subject.chat(prompt: prompt, context: context, examples: examples)
+      context "with prompt, messages, context and examples" do
+        let(:messages) do
+          [
+            {role: "user", content: "Can you answer questions?"},
+            {role: "assistant", content: "Yes, I can answer questions."}
+          ]
+        end
+        let(:history) do
+          [
+            {role: "system", content: context},
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi. How can I assist you today?"},
+            {role: "user", content: "Can you answer questions?"},
+            {role: "assistant", content: "Yes, I can answer questions."},
+            {role: "user", content: prompt}
+          ]
+        end
 
-  #       expect(response.chat_completion).to eq(answer)
-  #     end
+        it "sends context, prompt, messages and examples as joint messages" do
+          response = subject.chat(prompt: prompt, messages: messages, context: context, examples: examples)
 
-  #     it "sends context, messages and examples as joint messages" do
-  #       response = subject.chat(messages: [{role: "user", content: prompt}], context: context, examples: examples)
+          expect(response.chat_completion).to eq(answer)
+        end
+      end
 
-  #       expect(response.chat_completion).to eq(answer)
-  #     end
+      context "when context is already present in messages" do
+        let(:messages) do
+          [
+            {role: "system", content: context},
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi. How can I assist you today?"},
+            {role: "user", content: prompt}
+          ]
+        end
+        let(:history) do
+          [
+            {role: "system", content: "You are a human being"},
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi. How can I assist you today?"},
+            {role: "user", content: prompt}
+          ]
+        end
 
-  #     context "with prompt, messages, context and examples" do
-  #       let(:messages) do
-  #         [
-  #           {role: "user", content: "Can you answer questions?"},
-  #           {role: "assistant", content: "Yes, I can answer questions."}
-  #         ]
-  #       end
-  #       let(:history) do
-  #         [
-  #           {role: "system", content: context},
-  #           {role: "user", content: "Hello"},
-  #           {role: "assistant", content: "Hi. How can I assist you today?"},
-  #           {role: "user", content: "Can you answer questions?"},
-  #           {role: "assistant", content: "Yes, I can answer questions."},
-  #           {role: "user", content: prompt}
-  #         ]
-  #       end
+        it "it overrides system message with context" do
+          response = subject.chat(messages: messages, context: "You are a human being")
 
-  #       it "sends context, prompt, messages and examples as joint messages" do
-  #         response = subject.chat(prompt: prompt, messages: messages, context: context, examples: examples)
+          expect(response.chat_completion).to eq(answer)
+        end
+      end
 
-  #         expect(response.chat_completion).to eq(answer)
-  #       end
-  #     end
+      context "when last message is from user and prompt is present" do
+        let(:messages) do
+          [
+            {role: "system", content: context},
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi. How can I assist you today?"},
+            {role: "user", content: "I want to ask a question"}
+          ]
+        end
+        let(:history) do
+          [
+            {role: "system", content: context},
+            {role: "user", content: "Hello"},
+            {role: "assistant", content: "Hi. How can I assist you today?"},
+            {role: "user", content: "I want to ask a question\n#{prompt}"}
+          ]
+        end
 
-  #     context "when context is already present in messages" do
-  #       let(:messages) do
-  #         [
-  #           {role: "system", content: context},
-  #           {role: "user", content: "Hello"},
-  #           {role: "assistant", content: "Hi. How can I assist you today?"},
-  #           {role: "user", content: prompt}
-  #         ]
-  #       end
-  #       let(:history) do
-  #         [
-  #           {role: "system", content: "You are a human being"},
-  #           {role: "user", content: "Hello"},
-  #           {role: "assistant", content: "Hi. How can I assist you today?"},
-  #           {role: "user", content: prompt}
-  #         ]
-  #       end
+        it "it combines last message and prompt" do
+          response = subject.chat(prompt: prompt, messages: messages)
 
-  #       it "it overrides system message with context" do
-  #         response = subject.chat(messages: messages, context: "You are a human being")
+          expect(response.chat_completion).to eq(answer)
+        end
+      end
+    end
 
-  #         expect(response.chat_completion).to eq(answer)
-  #       end
-  #     end
+    context "with options" do
+      let(:temperature) { 0.75 }
+      let(:model) { "gpt-3.5-turbo-0301" }
 
-  #     context "when last message is from user and prompt is present" do
-  #       let(:messages) do
-  #         [
-  #           {role: "system", content: context},
-  #           {role: "user", content: "Hello"},
-  #           {role: "assistant", content: "Hi. How can I assist you today?"},
-  #           {role: "user", content: "I want to ask a question"}
-  #         ]
-  #       end
-  #       let(:history) do
-  #         [
-  #           {role: "system", content: context},
-  #           {role: "user", content: "Hello"},
-  #           {role: "assistant", content: "Hi. How can I assist you today?"},
-  #           {role: "user", content: "I want to ask a question\n#{prompt}"}
-  #         ]
-  #       end
+      it "sends prompt as message and additional params and returns a response message" do
+        response = subject.chat(prompt: prompt, model: model, temperature: temperature)
 
-  #       it "it combines last message and prompt" do
-  #         response = subject.chat(prompt: prompt, messages: messages)
+        expect(response.chat_completion).to eq(answer)
+      end
 
-  #         expect(response.chat_completion).to eq(answer)
-  #       end
-  #     end
-  #   end
+      context "with multiple choices" do
+        let(:n) { 2 }
+        let(:choices) do
+          [
+            {
+              "message" => {"role" => "assistant", "content" => answer},
+              "finish_reason" => "stop",
+              "index" => 0
+            },
+            {
+              "message" => {"role" => "assistant", "content" => answer_2},
+              "finish_reason" => "stop",
+              "index" => 1
+            }
+          ]
+        end
 
-  #   context "with options" do
-  #     let(:temperature) { 0.75 }
-  #     let(:model) { "gpt-3.5-turbo-0301" }
+        it "returns multiple response messages" do
+          response = subject.chat(prompt: prompt, model: model, temperature: temperature, n: 2)
 
-  #     it "sends prompt as message and additional params and returns a response message" do
-  #       response = subject.chat(prompt: prompt, model: model, temperature: temperature)
+          expect(response.completions).to eq(choices)
+        end
+      end
 
-  #       expect(response.chat_completion).to eq(answer)
-  #     end
+      context "functions" do
+        let(:parameters) { {parameters: {n: 1, messages: history, model: model, temperature: temperature, functions: [{foo: :bar}]}} }
 
-  #     context "with multiple choices" do
-  #       let(:n) { 2 }
-  #       let(:choices) do
-  #         [
-  #           {
-  #             "message" => {"role" => "assistant", "content" => answer},
-  #             "finish_reason" => "stop",
-  #             "index" => 0
-  #           },
-  #           {
-  #             "message" => {"role" => "assistant", "content" => answer_2},
-  #             "finish_reason" => "stop",
-  #             "index" => 1
-  #           }
-  #         ]
-  #       end
+        it "functions will be passed on options as accessor" do
+          subject.functions = [{foo: :bar}]
+          response = subject.chat(prompt: prompt, model: model, temperature: temperature)
 
-  #       it "returns multiple response messages" do
-  #         response = subject.chat(prompt: prompt, model: model, temperature: temperature, n: 2)
+          expect(response.chat_completion).to eq(answer)
+        end
+      end
+    end
 
-  #         expect(response.completions).to eq(choices)
-  #       end
-  #     end
+    context "with failed API call" do
+      let(:response) do
+        {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
+      end
 
-  #     context "functions" do
-  #       let(:parameters) { {parameters: {n: 1, messages: history, model: model, temperature: temperature, functions: [{foo: :bar}]}} }
+      it "raises an error" do
+        expect {
+          subject.chat(prompt: prompt)
+        }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
+      end
+    end
+  end
 
-  #       it "functions will be passed on options as accessor" do
-  #         subject.functions = [{foo: :bar}]
-  #         response = subject.chat(prompt: prompt, model: model, temperature: temperature)
+  describe "#summarize" do
+    let(:text) { "Text to summarize" }
 
-  #         expect(response.chat_completion).to eq(answer)
-  #       end
-  #     end
-  #   end
+    before do
+      allow(subject).to receive(:complete).and_return("Summary")
+    end
 
-  #   context "with failed API call" do
-  #     let(:response) do
-  #       {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
-  #     end
-
-  #     it "raises an error" do
-  #       expect {
-  #         subject.chat(prompt: prompt)
-  #       }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
-  #     end
-  #   end
-  # end
-
-  # describe "#summarize" do
-  #   let(:text) { "Text to summarize" }
-
-  #   before do
-  #     allow(subject).to receive(:complete).and_return("Summary")
-  #   end
-
-  #   it "returns a summary" do
-  #     expect(subject.summarize(text: text)).to eq("Summary")
-  #   end
-  # end
+    it "returns a summary" do
+      expect(subject.summarize(text: text)).to eq("Summary")
+    end
+  end
 end

--- a/spec/langchain/llm/azure_spec.rb
+++ b/spec/langchain/llm/azure_spec.rb
@@ -1,0 +1,541 @@
+# frozen_string_literal: true
+
+RSpec.describe Langchain::LLM::Azure do
+  let(:subject) do
+    described_class.new(
+      api_key: "123",
+      embedding_deployment_url: "http://localhost:1234/deployments/embedding",
+      chat_deployment_url: "http://localhost:1234/deployments/chat")
+  end
+
+  describe "#initialize" do
+    context "when only required options are passed" do
+      it "initializes the client without any errors" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when llm_options are passed" do
+      let(:subject) { described_class.new(api_key: "123", llm_options: {api_type: :azure}) }
+
+      it "initializes the client without any errors" do
+        expect { subject }.not_to raise_error
+      end
+
+      it "passes correct options to the client" do
+        # openai-ruby sets global configuration options here: https://github.com/alexrudall/ruby-openai/blob/main/lib/openai/client.rb
+        subject
+        expect(OpenAI.configuration.api_type).to eq(:azure)
+      end
+    end
+  end
+
+  describe "#embed" do
+    let(:result) { [-0.007097351, 0.0035200312, -0.0069700438] }
+    let(:parameters) do
+      {parameters: {input: "Hello World", model: "text-embedding-ada-002"}}
+    end
+    let(:response) do
+      {
+        "object" => "list",
+        "model" => parameters[:parameters][:model],
+        "data" => [
+          {
+            "object" => "embedding",
+            "index" => 0,
+            "embedding" => result
+          }
+        ],
+        "usage" => {
+          "prompt_tokens" => 2,
+          "total_tokens" => 2
+        }
+      }
+    end
+
+    before do
+      allow(subject.embed_client).to receive(:embeddings).with(parameters).and_return(response)
+    end
+
+    it "returns valid llm response object" do
+      response = subject.embed(text: "Hello World")
+
+      expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+      expect(response.model).to eq("text-embedding-ada-002")
+      expect(response.embedding).to eq([-0.007097351, 0.0035200312, -0.0069700438])
+      expect(response.prompt_tokens).to eq(2)
+      expect(response.completion_tokens).to eq(nil)
+      expect(response.total_tokens).to eq(2)
+    end
+
+    context "with default parameters" do
+      it "returns an embedding" do
+        response = subject.embed(text: "Hello World")
+
+        expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+        expect(response.embedding).to eq(result)
+      end
+    end
+
+    context "with text and parameters" do
+      let(:parameters) do
+        {parameters: {input: "Hello World", model: "text-embedding-ada-001", user: "id"}}
+      end
+
+      it "returns an embedding" do
+        response = subject.embed(text: "Hello World", model: "text-embedding-ada-001", user: "id")
+
+        expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+        expect(response.embedding).to eq(result)
+      end
+    end
+  end
+
+  # describe "#complete" do
+  #   let(:response) do
+  #     {
+  #       "id" => "cmpl-7BZg4cP5xzga4IyLI6u97WMepAJj2",
+  #       "object" => "chat.completion",
+  #       "created" => 1682993108,
+  #       "model" => "gpt-3.5-turbo",
+  #       "choices" => [
+  #         {
+  #           "message" => {
+  #             "role" => "assistant",
+  #             "content" => "The meaning of life is subjective and can vary from person to person."
+  #           },
+  #           "finish_reason" => "stop",
+  #           "index" => 0
+  #         }
+  #       ],
+  #       "usage" => {
+  #         "prompt_tokens" => 7,
+  #         "completion_tokens" => 16,
+  #         "total_tokens" => 23
+  #       }
+  #     }
+  #   end
+
+  #   before do
+  #     allow(subject.client).to receive(:chat).with(parameters).and_return(response)
+  #     allow(subject.client).to receive(:completions).with(parameters).and_return(response)
+  #   end
+
+  #   context "with default parameters" do
+  #     let(:parameters) do
+  #       {
+  #         parameters: {
+  #           n: 1,
+  #           model: "gpt-3.5-turbo",
+  #           messages: [{content: "Hello World", role: "user"}],
+  #           temperature: 0.0,
+  #           max_tokens: 4086
+  #         }
+  #       }
+  #     end
+
+  #     it "returns valid llm response object" do
+  #       response = subject.complete(prompt: "Hello World")
+
+  #       expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+  #       expect(response.model).to eq("gpt-3.5-turbo")
+  #       expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
+  #       expect(response.prompt_tokens).to eq(7)
+  #       expect(response.completion_tokens).to eq(16)
+  #       expect(response.total_tokens).to eq(23)
+  #     end
+
+  #     it "returns a completion" do
+  #       response = subject.complete(prompt: "Hello World")
+
+  #       expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+  #       expect(response.model).to eq("gpt-3.5-turbo")
+  #       expect(response.completions).to eq([{"message" => {"role" => "assistant", "content" => "The meaning of life is subjective and can vary from person to person."}, "finish_reason" => "stop", "index" => 0}])
+  #       expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
+  #     end
+  #   end
+
+  #   context "with custom default_options" do
+  #     context "with legacy model" do
+  #       let(:logger) { double("logger") }
+  #       let(:subject) {
+  #         described_class.new(
+  #           api_key: "123",
+  #           default_options: {completion_model_name: "text-davinci-003"}
+  #         )
+  #       }
+  #       let(:parameters) do
+  #         {
+  #           parameters:
+  #           {
+  #             n: 1,
+  #             model: "text-davinci-003",
+  #             prompt: "Hello World",
+  #             temperature: 0.0,
+  #             max_tokens: 4095
+  #           }
+  #         }
+  #       end
+
+  #       before do
+  #         allow(Langchain).to receive(:logger).and_return(logger)
+  #         allow(logger).to receive(:warn)
+  #       end
+
+  #       it "passes correct options to the completions method" do
+  #         expect(subject.client).to receive(:completions).with({
+  #           parameters: {
+  #             n: 1,
+  #             max_tokens: 4095,
+  #             model: "text-davinci-003",
+  #             prompt: "Hello World",
+  #             temperature: 0.0
+  #           }
+  #         }).and_return(response)
+  #         subject.complete(prompt: "Hello World")
+  #       end
+
+  #       it "logs a deprecation warning" do
+  #         expect(Langchain.logger).to receive(:warn).with("DEPRECATION WARNING: The model text-davinci-003 is deprecated. Please use gpt-3.5-turbo instead. Details: https://platform.openai.com/docs/deprecations/2023-07-06-gpt-and-embeddings")
+
+  #         subject.complete(prompt: "Hello World")
+  #       end
+  #     end
+
+  #     context "with new model" do
+  #       let(:subject) {
+  #         described_class.new(
+  #           api_key: "123",
+  #           default_options: {completion_model_name: "gpt-3.5-turbo-16k"}
+  #         )
+  #       }
+
+  #       let(:parameters) do
+  #         {
+  #           parameters: {
+  #             n: 1,
+  #             model: "gpt-3.5-turbo",
+  #             messages: [{content: "Hello World", role: "user"}],
+  #             temperature: 0.0,
+  #             max_tokens: 4086
+  #           }
+  #         }
+  #       end
+
+  #       it "passes correct options to the chat method" do
+  #         expect(subject.client).to receive(:chat).with({
+  #           parameters: {
+  #             n: 1,
+  #             max_tokens: 16374,
+  #             model: "gpt-3.5-turbo-16k",
+  #             messages: [{content: "Hello World", role: "user"}],
+  #             temperature: 0.0
+  #           }
+  #         }).and_return(response)
+  #         subject.complete(prompt: "Hello World")
+  #       end
+  #     end
+  #   end
+
+  #   context "with prompt and parameters" do
+  #     let(:parameters) do
+  #       {parameters: {n: 1, model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 1.0, max_tokens: 4086}}
+  #     end
+
+  #     it "returns a completion" do
+  #       response = subject.complete(prompt: "Hello World", model: "gpt-3.5-turbo", temperature: 1.0)
+
+  #       expect(response.completion).to eq("The meaning of life is subjective and can vary from person to person.")
+  #     end
+  #   end
+
+  #   context "with failed API call" do
+  #     let(:parameters) do
+  #       {parameters: {n: 1, model: "gpt-3.5-turbo", messages: [{content: "Hello World", role: "user"}], temperature: 0.0, max_tokens: 4086}}
+  #     end
+  #     let(:response) do
+  #       {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
+  #     end
+
+  #     it "raises an error" do
+  #       expect {
+  #         subject.complete(prompt: "Hello World")
+  #       }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
+  #     end
+  #   end
+  # end
+
+  # describe "#default_dimension" do
+  #   it "returns the default dimension" do
+  #     expect(subject.default_dimension).to eq(1536)
+  #   end
+  # end
+
+  # describe "#chat" do
+  #   let(:prompt) { "What is the meaning of life?" }
+  #   let(:model) { "gpt-3.5-turbo" }
+  #   let(:temperature) { 0.0 }
+  #   let(:n) { 1 }
+  #   let(:history) { [content: prompt, role: "user"] }
+  #   let(:parameters) { {parameters: {n: n, messages: history, model: model, temperature: temperature, max_tokens: be_between(4014, 4096)}} }
+  #   let(:answer) { "As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?" }
+  #   let(:answer_2) { "Alternative answer" }
+  #   let(:choices) do
+  #     [
+  #       {
+  #         "message" => {
+  #           "role" => "assistant",
+  #           "content" => answer
+  #         },
+  #         "finish_reason" => "stop",
+  #         "index" => 0
+  #       }
+  #     ]
+  #   end
+  #   let(:response) do
+  #     {
+  #       "id" => "chatcmpl-7Hcl1sXOtsaUBKJGGhNujEIwhauaD",
+  #       "object" => "chat.completion",
+  #       "created" => 1684434915,
+  #       "model" => model,
+  #       "usage" => {
+  #         "prompt_tokens" => 14,
+  #         "completion_tokens" => 25,
+  #         "total_tokens" => 39
+  #       },
+  #       "choices" => choices
+  #     }
+  #   end
+
+  #   before do
+  #     allow(subject.client).to receive(:chat).with(parameters).and_return(response)
+  #   end
+
+  #   it "returns valid llm response object" do
+  #     response = subject.chat(prompt: "What is the meaning of life?")
+
+  #     expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+  #     expect(response.model).to eq("gpt-3.5-turbo")
+  #     expect(response.chat_completion).to eq("As an AI language model, I don't have feelings, but I'm functioning well. How can I assist you today?")
+  #     expect(response.prompt_tokens).to eq(14)
+  #     expect(response.completion_tokens).to eq(25)
+  #     expect(response.total_tokens).to eq(39)
+  #   end
+
+  #   context "with prompt" do
+  #     it "sends prompt within messages" do
+  #       response = subject.chat(prompt: prompt)
+
+  #       expect(response).to be_a(Langchain::LLM::OpenAIResponse)
+  #       expect(response.model).to eq(model)
+  #       expect(response.completions).to eq(choices)
+  #       expect(response.chat_completion).to eq(answer)
+  #     end
+  #   end
+
+  #   context "with messages" do
+  #     it "sends messages" do
+  #       response = subject.chat(messages: [{role: "user", content: prompt}])
+
+  #       expect(response.chat_completion).to eq(answer)
+  #     end
+  #   end
+
+  #   context "with context" do
+  #     let(:context) { "You are a chatbot" }
+  #     let(:history) do
+  #       [
+  #         {role: "system", content: context},
+  #         {role: "user", content: prompt}
+  #       ]
+  #     end
+
+  #     it "sends context and prompt as messages" do
+  #       response = subject.chat(prompt: prompt, context: context)
+
+  #       expect(response.chat_completion).to eq(answer)
+  #     end
+
+  #     it "sends context and messages as joint messages" do
+  #       response = subject.chat(messages: [{role: "user", content: prompt}], context: context)
+
+  #       expect(response.chat_completion).to eq(answer)
+  #     end
+  #   end
+
+  #   context "with context and examples" do
+  #     let(:context) { "You are a chatbot" }
+  #     let(:examples) do
+  #       [
+  #         {role: "user", content: "Hello"},
+  #         {role: "assistant", content: "Hi. How can I assist you today?"}
+  #       ]
+  #     end
+  #     let(:history) do
+  #       [
+  #         {role: "system", content: context},
+  #         {role: "user", content: "Hello"},
+  #         {role: "assistant", content: "Hi. How can I assist you today?"},
+  #         {role: "user", content: prompt}
+  #       ]
+  #     end
+
+  #     it "sends context, prompt and examples as joint messages" do
+  #       response = subject.chat(prompt: prompt, context: context, examples: examples)
+
+  #       expect(response.chat_completion).to eq(answer)
+  #     end
+
+  #     it "sends context, messages and examples as joint messages" do
+  #       response = subject.chat(messages: [{role: "user", content: prompt}], context: context, examples: examples)
+
+  #       expect(response.chat_completion).to eq(answer)
+  #     end
+
+  #     context "with prompt, messages, context and examples" do
+  #       let(:messages) do
+  #         [
+  #           {role: "user", content: "Can you answer questions?"},
+  #           {role: "assistant", content: "Yes, I can answer questions."}
+  #         ]
+  #       end
+  #       let(:history) do
+  #         [
+  #           {role: "system", content: context},
+  #           {role: "user", content: "Hello"},
+  #           {role: "assistant", content: "Hi. How can I assist you today?"},
+  #           {role: "user", content: "Can you answer questions?"},
+  #           {role: "assistant", content: "Yes, I can answer questions."},
+  #           {role: "user", content: prompt}
+  #         ]
+  #       end
+
+  #       it "sends context, prompt, messages and examples as joint messages" do
+  #         response = subject.chat(prompt: prompt, messages: messages, context: context, examples: examples)
+
+  #         expect(response.chat_completion).to eq(answer)
+  #       end
+  #     end
+
+  #     context "when context is already present in messages" do
+  #       let(:messages) do
+  #         [
+  #           {role: "system", content: context},
+  #           {role: "user", content: "Hello"},
+  #           {role: "assistant", content: "Hi. How can I assist you today?"},
+  #           {role: "user", content: prompt}
+  #         ]
+  #       end
+  #       let(:history) do
+  #         [
+  #           {role: "system", content: "You are a human being"},
+  #           {role: "user", content: "Hello"},
+  #           {role: "assistant", content: "Hi. How can I assist you today?"},
+  #           {role: "user", content: prompt}
+  #         ]
+  #       end
+
+  #       it "it overrides system message with context" do
+  #         response = subject.chat(messages: messages, context: "You are a human being")
+
+  #         expect(response.chat_completion).to eq(answer)
+  #       end
+  #     end
+
+  #     context "when last message is from user and prompt is present" do
+  #       let(:messages) do
+  #         [
+  #           {role: "system", content: context},
+  #           {role: "user", content: "Hello"},
+  #           {role: "assistant", content: "Hi. How can I assist you today?"},
+  #           {role: "user", content: "I want to ask a question"}
+  #         ]
+  #       end
+  #       let(:history) do
+  #         [
+  #           {role: "system", content: context},
+  #           {role: "user", content: "Hello"},
+  #           {role: "assistant", content: "Hi. How can I assist you today?"},
+  #           {role: "user", content: "I want to ask a question\n#{prompt}"}
+  #         ]
+  #       end
+
+  #       it "it combines last message and prompt" do
+  #         response = subject.chat(prompt: prompt, messages: messages)
+
+  #         expect(response.chat_completion).to eq(answer)
+  #       end
+  #     end
+  #   end
+
+  #   context "with options" do
+  #     let(:temperature) { 0.75 }
+  #     let(:model) { "gpt-3.5-turbo-0301" }
+
+  #     it "sends prompt as message and additional params and returns a response message" do
+  #       response = subject.chat(prompt: prompt, model: model, temperature: temperature)
+
+  #       expect(response.chat_completion).to eq(answer)
+  #     end
+
+  #     context "with multiple choices" do
+  #       let(:n) { 2 }
+  #       let(:choices) do
+  #         [
+  #           {
+  #             "message" => {"role" => "assistant", "content" => answer},
+  #             "finish_reason" => "stop",
+  #             "index" => 0
+  #           },
+  #           {
+  #             "message" => {"role" => "assistant", "content" => answer_2},
+  #             "finish_reason" => "stop",
+  #             "index" => 1
+  #           }
+  #         ]
+  #       end
+
+  #       it "returns multiple response messages" do
+  #         response = subject.chat(prompt: prompt, model: model, temperature: temperature, n: 2)
+
+  #         expect(response.completions).to eq(choices)
+  #       end
+  #     end
+
+  #     context "functions" do
+  #       let(:parameters) { {parameters: {n: 1, messages: history, model: model, temperature: temperature, functions: [{foo: :bar}]}} }
+
+  #       it "functions will be passed on options as accessor" do
+  #         subject.functions = [{foo: :bar}]
+  #         response = subject.chat(prompt: prompt, model: model, temperature: temperature)
+
+  #         expect(response.chat_completion).to eq(answer)
+  #       end
+  #     end
+  #   end
+
+  #   context "with failed API call" do
+  #     let(:response) do
+  #       {"error" => {"code" => 400, "message" => "User location is not supported for the API use.", "type" => "invalid_request_error"}}
+  #     end
+
+  #     it "raises an error" do
+  #       expect {
+  #         subject.chat(prompt: prompt)
+  #       }.to raise_error(Langchain::LLM::ApiError, "OpenAI API error: User location is not supported for the API use.")
+  #     end
+  #   end
+  # end
+
+  # describe "#summarize" do
+  #   let(:text) { "Text to summarize" }
+
+  #   before do
+  #     allow(subject).to receive(:complete).and_return("Summary")
+  #   end
+
+  #   it "returns a summary" do
+  #     expect(subject.summarize(text: text)).to eq("Summary")
+  #   end
+  # end
+end

--- a/spec/langchain/llm/openai_spec.rb
+++ b/spec/langchain/llm/openai_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Langchain::LLM::OpenAI do
 
       it "passes correct options to the client" do
         # openai-ruby sets global configuration options here: https://github.com/alexrudall/ruby-openai/blob/main/lib/openai/client.rb
-        subject
-        expect(OpenAI.configuration.uri_base).to eq("http://localhost:1234")
+        result = subject
+        expect(result.client.uri_base).to eq("http://localhost:1234")
       end
     end
   end


### PR DESCRIPTION
Hi Andrei,

I've made an attempt at adding support for the Microsoft [Azure OpenAI Service](https://learn.microsoft.com/en-us/azure/ai-services/openai/) API. It uses the [ruby-openai ](https://github.com/alexrudall/ruby-openai) gem and there is some basic documentation there about using Azure. The main difference is that with Azure you deploy multiple models, one for embeddings and one for chat.  So you need to specify the `uri_base` parameter whenever you call the `OpenAI::Client` with the url of either your embed model deployment (ada-2) or your chat model deployment (gpt-35) based on the proper context.

I decided to just have the Azure class inherit from the OpenAI class since they are so similar and just update a few of the methods. I'm not sure if this is the best approach, or if you think I should try something else, perhaps keeping the classes separate but including the shared methods in a module? I also wasn't totally sure on the how to best approach specs so included some azure specs for the new methods but I also copied in a lot of redundant specs to the spec/langchain/llm/azure_spec.rb file that would call methods in the OpenAI class and are already tested in spec/langchain/llm/openai_spec.rb.

Also I had to update to version 5.2 of the ruby-openai gem in development in order to use Azure.

Please review and let me know if you have any thoughts or changes I could make. Thanks!