### PR TITLE
Enable use of GPT-4 Turbo chat completions

### DIFF
--- a/lib/langchain/utils/token_length/ai21_validator.rb
+++ b/lib/langchain/utils/token_length/ai21_validator.rb
@@ -30,6 +30,7 @@ module Langchain
         def self.token_limit(model_name)
           TOKEN_LIMITS[model_name]
         end
+        alias_method :completion_token_limit, :token_limit
       end
     end
   end

--- a/lib/langchain/utils/token_length/ai21_validator.rb
+++ b/lib/langchain/utils/token_length/ai21_validator.rb
@@ -30,7 +30,7 @@ module Langchain
         def self.token_limit(model_name)
           TOKEN_LIMITS[model_name]
         end
-        alias_method :completion_token_limit, :token_limit
+        singleton_class.alias_method :completion_token_limit, :token_limit
       end
     end
   end

--- a/lib/langchain/utils/token_length/base_validator.rb
+++ b/lib/langchain/utils/token_length/base_validator.rb
@@ -20,6 +20,9 @@ module Langchain
           end
 
           leftover_tokens = token_limit(model_name) - text_token_length
+          # Some models have a separate token limit for completion (e.g. GPT-4 Turbo)
+          # We want the lower of the two limits
+          leftover_tokens = [leftover_tokens, completion_token_limit(model_name)].min
 
           # Raise an error even if whole prompt is equal to the model's token limit (leftover_tokens == 0)
           if leftover_tokens < 0

--- a/lib/langchain/utils/token_length/cohere_validator.rb
+++ b/lib/langchain/utils/token_length/cohere_validator.rb
@@ -38,7 +38,7 @@ module Langchain
         def self.token_limit(model_name)
           TOKEN_LIMITS[model_name]
         end
-        alias_method :completion_token_limit, :token_limit
+        singleton_class.alias_method :completion_token_limit, :token_limit
       end
     end
   end

--- a/lib/langchain/utils/token_length/cohere_validator.rb
+++ b/lib/langchain/utils/token_length/cohere_validator.rb
@@ -38,6 +38,7 @@ module Langchain
         def self.token_limit(model_name)
           TOKEN_LIMITS[model_name]
         end
+        alias_method :completion_token_limit, :token_limit
       end
     end
   end

--- a/lib/langchain/utils/token_length/google_palm_validator.rb
+++ b/lib/langchain/utils/token_length/google_palm_validator.rb
@@ -46,6 +46,7 @@ module Langchain
         def self.token_limit(model_name)
           TOKEN_LIMITS.dig(model_name, "input_token_limit")
         end
+        alias_method :completion_token_limit, :token_limit
       end
     end
   end

--- a/lib/langchain/utils/token_length/google_palm_validator.rb
+++ b/lib/langchain/utils/token_length/google_palm_validator.rb
@@ -46,7 +46,7 @@ module Langchain
         def self.token_limit(model_name)
           TOKEN_LIMITS.dig(model_name, "input_token_limit")
         end
-        alias_method :completion_token_limit, :token_limit
+        singleton_class.alias_method :completion_token_limit, :token_limit
       end
     end
   end

--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -29,6 +29,8 @@ module Langchain
           "gpt-4-32k" => 32768,
           "gpt-4-32k-0314" => 32768,
           "gpt-4-32k-0613" => 32768,
+          "gpt-4-1106-preview" => 128000,
+          "gpt-4-vision-preview" => 128000,
           "text-curie-001" => 2049,
           "text-babbage-001" => 2049,
           "text-ada-001" => 2049,

--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -10,6 +10,14 @@ module Langchain
       # It is used to validate the token length before the API call is made
       #
       class OpenAIValidator < BaseValidator
+        COMPLETION_TOKEN_LIMITS = {
+          # GPT-4 Turbo has a separate token limit for completion
+          # Source:
+          # https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
+          "gpt-4-1106-preview" => 4096,
+          "gpt-4-vision-preview" => 4096
+        }
+
         TOKEN_LIMITS = {
           # Source:
           # https://platform.openai.com/docs/api-reference/embeddings
@@ -54,6 +62,10 @@ module Langchain
 
         def self.token_limit(model_name)
           TOKEN_LIMITS[model_name]
+        end
+
+        def self.completion_token_limit(model_name)
+          COMPLETION_TOKEN_LIMITS[model_name] || token_limit(model_name)
         end
       end
     end

--- a/spec/langchain/utils/token_length/openai_validator_spec.rb
+++ b/spec/langchain/utils/token_length/openai_validator_spec.rb
@@ -29,6 +29,36 @@ RSpec.describe Langchain::Utils::TokenLength::OpenAIValidator do
         end
       end
 
+      context "when the model has a separate completion token limit" do
+        let(:model) { "gpt-4-1106-preview" }
+
+        context "where the leftover tokens are great than the completion token limit" do
+          # 202 tokens
+          let(:content) { "lorem ipsum " * 100 }
+
+          it "does not raise an error" do
+            expect { subject }.not_to raise_error
+          end
+
+          it "returns the correct max_tokens" do
+            expect(subject).to eq(4096)
+          end
+        end
+
+        context "where the leftover tokens are below the completion token limit" do
+          # 126002 tokens, just under the input token limit of gpt-4-1106-preview
+          let(:content) { "lorem ipsum " * 63_000 }
+
+          it "does not raise an error" do
+            expect { subject }.not_to raise_error
+          end
+
+          it "returns the correct max_tokens" do
+            expect(subject).to eq(1998)
+          end
+        end
+      end
+
       context "when the token is equal to the limit" do
         let(:content) { "lorem ipsum" * 9000 }
         let(:model) { "text-embedding-ada-002" }


### PR DESCRIPTION
# Motivation

The new GPT 4 Turbo models are not represented in the TokenLength validators, so trying to use them will raise an error.

# Changes

In addition to simply adding entries for the `gpt-4-1106-preview` and `gpt-4-vision-preview` models with their token length (128k), I needed to introduce the concept of a completion token limit, because GPT 4 Turbo has a 4,096 token limit for completions. This shows up as a new `#completion_token_limit` class which falls back to `#token_limit` if no key is present for the model. Since this is only applicable to the OpenAI validator, the other LLM validators call `singleton_class.alias_method :completion_token_limit, :token_limit`. Short and sweet.