### PR TITLE
Proper mock AWS_REGION to fix aws_bedrock_spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
   tests:
     env:
       POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/postgres
-      AWS_REGION: us-east-2
 
     runs-on: ubuntu-latest
     strategy:

--- a/spec/langchain/llm/aws_bedrock_spec.rb
+++ b/spec/langchain/llm/aws_bedrock_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Langchain::LLM::AwsBedrock do
   let(:subject) { described_class.new }
 
   before do
-    stub_const("ENV", ENV.to_hash.merge(AWS_REGION: "us-east-1"))
+    stub_const("ENV", ENV.to_hash.merge("AWS_REGION" => "us-east-1"))
   end
 
   describe "#complete" do


### PR DESCRIPTION
Hi, 
As my first contribution, here is a small fix to properly mock `ENV["AWS_REGION"]` in aws_bedrock_spec.rb.
The spec were failing for me locally.
Related to https://github.com/andreibondarev/langchainrb/pull/384
