### PR TITLE
Support a :max_tokens param in OpenAIValidator.validate_max_tokens

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -69,7 +69,7 @@ module Langchain::LLM
       return legacy_complete(prompt, parameters) if is_legacy_model?(parameters[:model])
 
       parameters[:messages] = compose_chat_messages(prompt: prompt)
-      parameters[:max_tokens] = validate_max_tokens(parameters[:messages], parameters[:model])
+      parameters[:max_tokens] = validate_max_tokens(parameters[:messages], parameters[:model], parameters[:max_tokens])
 
       response = with_api_error_handling do
         client.chat(parameters: parameters)
@@ -131,7 +131,7 @@ module Langchain::LLM
       if functions
         parameters[:functions] = functions
       else
-        parameters[:max_tokens] = validate_max_tokens(parameters[:messages], parameters[:model])
+        parameters[:max_tokens] = validate_max_tokens(parameters[:messages], parameters[:model], parameters[:max_tokens])
       end
 
       response = with_api_error_handling { client.chat(parameters: parameters) }
@@ -230,8 +230,8 @@ module Langchain::LLM
       response
     end
 
-    def validate_max_tokens(messages, model)
-      LENGTH_VALIDATOR.validate_max_tokens!(messages, model)
+    def validate_max_tokens(messages, model, max_tokens = nil)
+      LENGTH_VALIDATOR.validate_max_tokens!(messages, model, max_tokens: max_tokens)
     end
 
     def extract_response(response)

--- a/lib/langchain/utils/token_length/base_validator.rb
+++ b/lib/langchain/utils/token_length/base_validator.rb
@@ -25,11 +25,6 @@ module Langchain
           # We want the lower of the two limits
           max_tokens = [leftover_tokens, completion_token_limit(model_name)].min
 
-          # If :max_tokens is passed in, take the lower of it and the calculated max_tokens
-          unless options[:max_tokens].nil?
-            max_tokens = [max_tokens, options[:max_tokens]].min
-          end
-
           # Raise an error even if whole prompt is equal to the model's token limit (leftover_tokens == 0)
           if max_tokens < 0
             raise limit_exceeded_exception(token_limit(model_name), text_token_length)

--- a/lib/langchain/utils/token_length/base_validator.rb
+++ b/lib/langchain/utils/token_length/base_validator.rb
@@ -20,16 +20,22 @@ module Langchain
           end
 
           leftover_tokens = token_limit(model_name) - text_token_length
-          # Some models have a separate token limit for completion (e.g. GPT-4 Turbo)
+
+          # Some models have a separate token limit for completions (e.g. GPT-4 Turbo)
           # We want the lower of the two limits
-          leftover_tokens = [leftover_tokens, completion_token_limit(model_name)].min
+          max_tokens = [leftover_tokens, completion_token_limit(model_name)].min
+
+          # If :max_tokens is passed in, take the lower of it and the calculated max_tokens
+          unless options[:max_tokens].nil?
+            max_tokens = [max_tokens, options[:max_tokens]].min
+          end
 
           # Raise an error even if whole prompt is equal to the model's token limit (leftover_tokens == 0)
-          if leftover_tokens < 0
+          if max_tokens < 0
             raise limit_exceeded_exception(token_limit(model_name), text_token_length)
           end
 
-          leftover_tokens
+          max_tokens
         end
 
         def self.limit_exceeded_exception(limit, length)

--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -67,6 +67,12 @@ module Langchain
         def self.completion_token_limit(model_name)
           COMPLETION_TOKEN_LIMITS[model_name] || token_limit(model_name)
         end
+
+        # If :max_tokens is passed in, take the lower of it and the calculated max_tokens
+        def self.validate_max_tokens!(content, model_name, options = {})
+          max_tokens = super(content, model_name, options)
+          [options[:max_tokens], max_tokens].reject(&:nil?).min
+        end
       end
     end
   end

--- a/spec/langchain/utils/token_length/openai_validator_spec.rb
+++ b/spec/langchain/utils/token_length/openai_validator_spec.rb
@@ -77,6 +77,28 @@ RSpec.describe Langchain::Utils::TokenLength::OpenAIValidator do
           expect(subject).to eq(0)
         end
       end
+
+      context "when :max_tokens is passed in" do
+        context "when :max_tokens is lower than the leftover tokens" do
+          subject { described_class.validate_max_tokens!(content, model, max_tokens: 10) }
+          let(:content) { "lorem ipsum" * 100 }
+          let(:model) { "gpt-4" }
+
+          it "returns the correct max_tokens" do
+            expect(subject).to eq(10)
+          end
+        end
+
+        context "when :max_tokens is greater than the leftover tokens" do
+          subject { described_class.validate_max_tokens!(content, model, max_tokens: 8000) }
+          let(:content) { "lorem ipsum" * 100 }
+          let(:model) { "gpt-4" }
+
+          it "returns the correct max_tokens" do
+            expect(subject).to eq(7892)
+          end
+        end
+      end
     end
 
     context "with array argument" do


### PR DESCRIPTION
# Motivation

Two of OpenAI's API endpoints (chat and completions) take a `:max_tokens` param, but these are ignored in the current token validation / calculation method `BaseValidator.validate_max_tokens` (that method name is slightly misleading as it does more than validate it, but that's for another PR).

# Changes

Fortunately the changes were minimal. `BaseValidator.validate_max_tokens` already takes an options param, and I just worked on this method in #379. Like in #379 we want to take the lower of two token limits. In this case it's between the max calculated from the leftover tokens and `options[:max_tokens]`. I added two specs for when it's passed in (one for when it's lower, one for when it's higher than the calculated max).

Addresses #365 
