### PR TITLE
Updated Qdrant add_texts method to allow dynamic payloads

### DIFF
--- a/lib/langchain/vectorsearch/qdrant.rb
+++ b/lib/langchain/vectorsearch/qdrant.rb
@@ -49,9 +49,9 @@ module Langchain::Vectorsearch
 
       Array(texts).each_with_index do |text, i|
         id = ids[i] || SecureRandom.uuid
-        batch[:ids].push(id)        
+        batch[:ids].push(id)
         batch[:vectors].push(llm.embed(text: text).embedding)
-        batch[:payloads].push(payload.present? ? {content: text}.merge!(payload) : {content: text})
+        batch[:payloads].push({content: text}.merge(payload))
       end
 
       client.points.upsert(

--- a/lib/langchain/vectorsearch/qdrant.rb
+++ b/lib/langchain/vectorsearch/qdrant.rb
@@ -44,14 +44,14 @@ module Langchain::Vectorsearch
     # Add a list of texts to the index
     # @param texts [Array<String>] The list of texts to add
     # @return [Hash] The response from the server
-    def add_texts(texts:, ids: [], payloads: [])
+    def add_texts(texts:, ids: [], payload: {})
       batch = {ids: [], vectors: [], payloads: []}
 
       Array(texts).each_with_index do |text, i|
         id = ids[i] || SecureRandom.uuid
         batch[:ids].push(id)        
         batch[:vectors].push(llm.embed(text: text).embedding)
-        batch[:payloads].push(payloads[i] ? {content: text}.merge(payloads[i]) : {content: text})
+        batch[:payloads].push(payload.present? ? {content: text}.merge!(payload) : {content: text})
       end
 
       client.points.upsert(

--- a/lib/langchain/vectorsearch/qdrant.rb
+++ b/lib/langchain/vectorsearch/qdrant.rb
@@ -44,14 +44,14 @@ module Langchain::Vectorsearch
     # Add a list of texts to the index
     # @param texts [Array<String>] The list of texts to add
     # @return [Hash] The response from the server
-    def add_texts(texts:, ids: [])
+    def add_texts(texts:, ids: [], payloads: [])
       batch = {ids: [], vectors: [], payloads: []}
 
       Array(texts).each_with_index do |text, i|
         id = ids[i] || SecureRandom.uuid
         batch[:ids].push(id)
         batch[:vectors].push(llm.embed(text: text).embedding)
-        batch[:payloads].push({content: text})
+        batch[:payloads].push(payloads[i] || {content: text})
       end
 
       client.points.upsert(

--- a/lib/langchain/vectorsearch/qdrant.rb
+++ b/lib/langchain/vectorsearch/qdrant.rb
@@ -49,9 +49,9 @@ module Langchain::Vectorsearch
 
       Array(texts).each_with_index do |text, i|
         id = ids[i] || SecureRandom.uuid
-        batch[:ids].push(id)
+        batch[:ids].push(id)        
         batch[:vectors].push(llm.embed(text: text).embedding)
-        batch[:payloads].push(payloads[i] || {content: text})
+        batch[:payloads].push(payloads[i] ? {content: text}.merge(payloads[i]) : {content: text})
       end
 
       client.points.upsert(

--- a/spec/langchain/vectorsearch/qdrant_spec.rb
+++ b/spec/langchain/vectorsearch/qdrant_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Langchain::Vectorsearch::Qdrant do
     context "when merging provided payload with default payload" do
       let(:provided_payload) { {author: "Test Author", extra: "Extra Data"} }
       let(:expected_payload) { [{content: text}.merge(provided_payload)] }
-  
+
       it "merges provided payload into default" do
         expect(subject.client.points).to receive(:upsert).with(
           hash_including(
@@ -87,7 +87,7 @@ RSpec.describe Langchain::Vectorsearch::Qdrant do
             )
           )
         ).and_return(true)
-  
+
         result = subject.add_texts(texts: [text], ids: [1], payload: provided_payload)
         expect(result).to eq(true)
       end

--- a/spec/langchain/vectorsearch/qdrant_spec.rb
+++ b/spec/langchain/vectorsearch/qdrant_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe Langchain::Vectorsearch::Qdrant do
     it "adds texts" do
       expect(subject.add_texts(texts: [text], ids: [1])).to eq(true)
     end
+
+    context "when merging provided payload with default payload" do
+      let(:provided_payload) { {author: "Test Author", extra: "Extra Data"} }
+      let(:expected_payload) { [{content: text}.merge(provided_payload)] }
+  
+      it "merges provided payload into default" do
+        expect(subject.client.points).to receive(:upsert).with(
+          hash_including(
+            batch: hash_including(
+              payloads: expected_payload
+            )
+          )
+        ).and_return(true)
+  
+        result = subject.add_texts(texts: [text], ids: [1], payload: provided_payload)
+        expect(result).to eq(true)
+      end
+    end
   end
 
   describe "updates_texts" do


### PR DESCRIPTION
The key changes:
- Accept a payloads argument to allow custom payloads
- Use the passed payload if provided, else default to {content: text}