### PR TITLE
[Openai] Correcly handle chat with streaming and multiple choices

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -29,7 +29,6 @@ module Langchain::LLM
     LENGTH_VALIDATOR = Langchain::Utils::TokenLength::OpenAIValidator
 
     attr_accessor :functions
-    attr_accessor :response_chunks
 
     def initialize(api_key:, llm_options: {}, default_options: {})
       depends_on "ruby-openai", req: "openai"
@@ -137,6 +136,7 @@ module Langchain::LLM
 
       response = with_api_error_handling { client.chat(parameters: parameters) }
       response = response_from_chunks if block
+      reset_response_chunks
       Langchain::LLM::OpenAIResponse.new(response)
     end
 
@@ -157,6 +157,12 @@ module Langchain::LLM
     end
 
     private
+
+    attr_reader :response_chunks
+
+    def reset_response_chunks
+      @response_chunks = []
+    end
 
     def is_legacy_model?(model)
       LEGACY_COMPLETION_MODELS.any? { |legacy_model| model.include?(legacy_model) }


### PR DESCRIPTION
## Context
Following up on this #387. The final response coming from `Langchain::LLM:Openai#chat` with when streaming and multiple choices (n>1) is not correct.

This change correctly re-constructs the final response by grouping chunks accordingly

### Example
```ruby
llm = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
response = llm.chat(prompt: "hello", n: 2) do |chunk|
  puts chunk
end
```

#### Before
```
#<Langchain::LLM::OpenAIResponse:0x0000000109c094c8
 @model=nil,                              
 @raw_response=                           
  {"id"=>"chatcmpl-8Kl5uHVZrudHk6ofJcwctne5PzLIP",
   "object"=>"chat.completion.chunk",     
   "created"=>1699958282,                 
   "model"=>"gpt-3.5-turbo-0613",         
   "choices"=>[{"message"=>{"role"=>"assistant", "content"=>"HelloHello!! How How can can I I assist assist you you today today??"}}]}>
```

#### After
```
#<Langchain::LLM::OpenAIResponse:0x0000000110d75da0
 @model=nil,                              
 @raw_response=                           
  {"id"=>"chatcmpl-8KlZeQ5tszjiyVvuTnnZp3CcdaOKE",
   "object"=>"chat.completion.chunk",     
   "created"=>1699960126,                 
   "model"=>"gpt-3.5-turbo-0613",         
   "choices"=>                            
    [{"index"=>0, "message"=>{"role"=>"assistant", "content"=>"Hello! How can I assist you today?"}, "finish_reason"=>"stop"},
     {"index"=>1, "message"=>{"role"=>"assistant", "content"=>"Hello! How can I assist you today?"}, "finish_reason"=>"stop"}]}>
 ```


