### PR TITLE
Support new GPT-3.5 Turbo model `gpt-3.5-turbo-1106`

### DIFF
--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -26,6 +26,7 @@ module Langchain
           "gpt-3.5-turbo" => 4096,
           "gpt-3.5-turbo-0301" => 4096,
           "gpt-3.5-turbo-0613" => 4096,
+          "gpt-3.5-turbo-1106" => 16385,
           "gpt-3.5-turbo-16k" => 16384,
           "gpt-3.5-turbo-16k-0613" => 16384,
           "text-davinci-003" => 4097,

--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -15,7 +15,8 @@ module Langchain
           # Source:
           # https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
           "gpt-4-1106-preview" => 4096,
-          "gpt-4-vision-preview" => 4096
+          "gpt-4-vision-preview" => 4096,
+          "gpt-3.5-turbo-1106" => 4096
         }
 
         TOKEN_LIMITS = {


### PR DESCRIPTION
There is a new model `gpt-3.5-turbo-1106` which replaces old GPT-3.5 Turbo models.

This PR adds the token limit for `gpt-3.5-turbo-1106` 

https://platform.openai.com/docs/models/gpt-3-5

Currently we get the below error if we try to use this model:
```
lib/langchain/utils/token_length/base_validator.rb:22:in `validate_max_tokens!': undefined method `-' for nil:NilClass (NoMethodError)

          leftover_tokens = token_limit(model_name) - text_token_length```