### PR TITLE
add epsilla db connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   tests:
     env:
       POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      EPSILLA_HOST: 127.0.0.1
 
     runs-on: ubuntu-latest
     strategy:
@@ -25,6 +26,13 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      epsilla:
+        image: epsilla/vectordb
+        ports:
+          - 8888:8888
+        # Faster health checks
+        options: >-
+          --health-interval 1s
 
     steps:
       - uses: actions/checkout@master
@@ -37,7 +45,7 @@ jobs:
 
       - name: Run tests
         run: |
-          bundle exec rspec 
+          bundle exec rspec
   linters:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   tests:
     env:
       POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/postgres
-      EPSILLA_HOST: 127.0.0.1
+      EPSILLA_URL: http://127.0.0.1:8888
 
     runs-on: ubuntu-latest
     strategy:

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,3 @@ gem "rubocop"
 
 # Temporary fix until https://github.com/github/graphql-client/pull/314 is merged
 gem "graphql-client", git: "https://github.com/rmosolgo/graphql-client.git", branch: "start-migrating"
-
-gem "epsilla-ruby", "~> 0.0.4"

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ gem "rubocop"
 
 # Temporary fix until https://github.com/github/graphql-client/pull/314 is merged
 gem "graphql-client", git: "https://github.com/rmosolgo/graphql-client.git", branch: "start-migrating"
+
+gem "epsilla-ruby", "~> 0.0.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
       elasticsearch-api (= 8.2.2)
     elasticsearch-api (8.2.2)
       multi_json
+    epsilla-ruby (0.0.4)
+      faraday (>= 1)
     eqn (1.6.5)
       treetop (>= 1.2.0)
     erubi (1.12.0)
@@ -387,6 +389,7 @@ DEPENDENCIES
   docx (~> 0.8.0)
   dotenv-rails (~> 2.7.6)
   elasticsearch (~> 8.2.0)
+  epsilla-ruby (~> 0.0.4)
   eqn (~> 1.6.5)
   google-apis-aiplatform_v1 (~> 0.7)
   google_palm_api (~> 0.1.3)

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Langchain.rb provides a convenient unified interface on top of supported vectors
 | Database                                                                                   | Open-source        | Cloud offering     |
 | --------                                                                                   |:------------------:| :------------:     |
 | [Chroma](https://trychroma.com/?utm_source=langchainrb&utm_medium=github)                  | ✅                 | ✅                 |
+| [Epsilla](https://epsilla.com/?utm_source=langchainrb&utm_medium=github)                   | ✅                 | ✅                 |
 | [Hnswlib](https://github.com/nmslib/hnswlib/?utm_source=langchainrb&utm_medium=github)     | ✅                 | ❌                 |
 | [Milvus](https://milvus.io/?utm_source=langchainrb&utm_medium=github)                      | ✅                 | ✅ Zilliz Cloud    |
 | [Pinecone](https://www.pinecone.io/?utm_source=langchainrb&utm_medium=github)              | ❌                 | ✅                 |
@@ -342,6 +343,7 @@ client = Langchain::Vectorsearch::Weaviate.new(
 You can instantiate any other supported vector search database:
 ```ruby
 client = Langchain::Vectorsearch::Chroma.new(...)   # `gem "chroma-db", "~> 0.6.0"`
+client = Langchain::Vectorsearch::Epsilla.new(...)  # `gem "epsilla-ruby", "~> 0.0.3"`
 client = Langchain::Vectorsearch::Hnswlib.new(...)  # `gem "hnswlib", "~> 0.8.1"`
 client = Langchain::Vectorsearch::Milvus.new(...)   # `gem "milvus", "~> 0.9.2"`
 client = Langchain::Vectorsearch::Pinecone.new(...) # `gem "pinecone", "~> 0.1.6"`

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -72,4 +72,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sequel", "~> 5.68.0"
   spec.add_development_dependency "weaviate-ruby", "~> 0.8.9"
   spec.add_development_dependency "wikipedia-client", "~> 1.17.0"
+  spec.add_development_dependency "epsilla-ruby", "~> 0.0.4"
 end

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cohere-ruby", "~> 0.9.7"
   spec.add_development_dependency "docx", "~> 0.8.0"
   spec.add_development_dependency "elasticsearch", "~> 8.2.0"
+  spec.add_development_dependency "epsilla-ruby", "~> 0.0.4"
   spec.add_development_dependency "eqn", "~> 1.6.5"
   spec.add_development_dependency "google-apis-aiplatform_v1", "~> 0.7"
   spec.add_development_dependency "google_palm_api", "~> 0.1.3"
@@ -72,5 +73,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sequel", "~> 5.68.0"
   spec.add_development_dependency "weaviate-ruby", "~> 0.8.9"
   spec.add_development_dependency "wikipedia-client", "~> 1.17.0"
-  spec.add_development_dependency "epsilla-ruby", "~> 0.0.4"
 end

--- a/lib/langchain/vectorsearch/base.rb
+++ b/lib/langchain/vectorsearch/base.rb
@@ -7,6 +7,7 @@ module Langchain::Vectorsearch
   # == Available vector databases
   #
   # - {Langchain::Vectorsearch::Chroma}
+  # - {Langchain::Vectorsearch::Epsilla}
   # - {Langchain::Vectorsearch::Elasticsearch}
   # - {Langchain::Vectorsearch::Hnswlib}
   # - {Langchain::Vectorsearch::Milvus}
@@ -29,10 +30,11 @@ module Langchain::Vectorsearch
   #     )
   #
   #     # You can instantiate other supported vector databases the same way:
+  #     epsilla  = Langchain::Vectorsearch::Epsilla.new(...)
   #     milvus   = Langchain::Vectorsearch::Milvus.new(...)
   #     qdrant   = Langchain::Vectorsearch::Qdrant.new(...)
   #     pinecone = Langchain::Vectorsearch::Pinecone.new(...)
-  #     chrome   = Langchain::Vectorsearch::Chroma.new(...)
+  #     chroma   = Langchain::Vectorsearch::Chroma.new(...)
   #     pgvector = Langchain::Vectorsearch::Pgvector.new(...)
   #
   # == Schema Creation

--- a/lib/langchain/vectorsearch/epsilla.rb
+++ b/lib/langchain/vectorsearch/epsilla.rb
@@ -3,6 +3,7 @@
 require "securerandom"
 require "json"
 require "timeout"
+require "uri"
 
 module Langchain::Vectorsearch
   class Epsilla < Base
@@ -13,18 +14,21 @@ module Langchain::Vectorsearch
     #     gem "epsilla-ruby", "~> 0.0.3"
     #
     # Usage:
-    #     epsilla = Langchain::Vectorsearch::Epsilla.new(protocol:, host:, db_name:, db_path:, index_name:, llm:, port:)
+    #     epsilla = Langchain::Vectorsearch::Epsilla.new(url:, db_name:, db_path:, index_name:, llm:)
     #
     # Initialize Epsilla client
-    # @param protocol [String] The protocol to use, e.g. http or https
-    # @param host [String] The host to connect to
+    # @param url [String] URL to connect to the Epsilla db instance, protocol://host:port
     # @param db_name [String] The name of the database to use
     # @param db_path [String] The path to the database to use
     # @param index_name [String] The name of the Epsilla table to use
     # @param llm [Object] The LLM client to use
-    # @param port [Integer] The port to connect to, default 8888
-    def initialize(protocol:, host:, db_name:, db_path:, index_name:, llm:, port: 8888)
+    def initialize(url:, db_name:, db_path:, index_name:, llm:)
       depends_on "epsilla-ruby", req: "epsilla"
+
+      uri = URI.parse(url)
+      protocol = uri.scheme
+      host = uri.host
+      port = uri.port
 
       @client = ::Epsilla::Client.new(protocol, host, port)
 

--- a/lib/langchain/vectorsearch/epsilla.rb
+++ b/lib/langchain/vectorsearch/epsilla.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "json"
+require "timeout"
+
+module Langchain::Vectorsearch
+  class Epsilla < Base
+    #
+    # Wrapper around Epsilla client library
+    #
+    # Gem requirements:
+    #     gem "epsilla-ruby", "~> 0.0.3"
+    #
+    # Usage:
+    #     epsilla = Langchain::Vectorsearch::Epsilla.new(protocol:, host:, db_name:, db_path:, index_name:, llm:, port:)
+    #
+    # Initialize Epsilla client
+    # @param protocol [String] The protocol to use, e.g. http or https
+    # @param host [String] The host to connect to
+    # @param db_name [String] The name of the database to use
+    # @param db_path [String] The path to the database to use
+    # @param index_name [String] The name of the Epsilla table to use
+    # @param llm [Object] The LLM client to use
+    # @param port [Integer] The port to connect to, default 8888
+    def initialize(protocol:, host:, db_name:, db_path:, index_name:, llm:, port: 8888)
+      depends_on "epsilla-ruby", req: "epsilla"
+
+      @client = ::Epsilla::Client.new(protocol, host, port)
+
+      Timeout.timeout(5) do
+        status_code, response = @client.database.load_db(db_name, db_path)
+
+        if status_code != 200
+          if status_code == 500 && response["message"].include?("already loaded")
+            Langchain.logger.info("Database already loaded")
+          else
+            raise "Failed to load database: #{response}"
+          end
+        end
+      end
+
+      @client.database.use_db(db_name)
+
+      @db_name = db_name
+      @db_path = db_path
+      @table_name = index_name
+
+      @vector_dimension = llm.default_dimension
+
+      super(llm: llm)
+    end
+
+    # Create a table using the index_name passed in the constructor
+    def create_default_schema
+      status_code, response = @client.database.create_table(@table_name, [
+        {"name" => "ID", "dataType" => "STRING", "primaryKey" => true},
+        {"name" => "Doc", "dataType" => "STRING"},
+        {"name" => "Embedding", "dataType" => "VECTOR_FLOAT", "dimensions" => @vector_dimension}
+      ])
+      raise "Failed to create table: #{response}" if status_code != 200
+
+      response
+    end
+
+    # Drop the table using the index_name passed in the constructor
+    def destroy_default_schema
+      status_code, response = @client.database.drop_table(@table_name)
+      raise "Failed to drop table: #{response}" if status_code != 200
+
+      response
+    end
+
+    # Add a list of texts to the database
+    # @param texts [Array<String>] The list of texts to add
+    def add_texts(texts:)
+      data = texts.map do |text|
+        {Doc: text, Embedding: llm.embed(text: text).embedding, ID: SecureRandom.uuid}
+      end
+
+      status_code, response = @client.database.insert(@table_name, data)
+      raise "Failed to insert texts: #{response}" if status_code != 200
+      response
+    end
+
+    # Search for similar texts
+    # @param query [String] The text to search for
+    # @param k [Integer] The number of results to return
+    # @return [String] The response from the server
+    def similarity_search(query:, k: 4)
+      embedding = llm.embed(text: query).embedding
+
+      similarity_search_by_vector(
+        embedding: embedding,
+        k: k
+      )
+    end
+
+    # Search for entries by embedding
+    # @param embedding [Array<Float>] The embedding to search for
+    # @param k [Integer] The number of results to return
+    # @return [String] The response from the server
+    def similarity_search_by_vector(embedding:, k: 4)
+      status_code, response = @client.database.query(@table_name, "Embedding", embedding, ["Doc"], k, false)
+      raise "Failed to do similarity search: #{response}" if status_code != 200
+
+      data = JSON.parse(response)["result"]
+      data.map { |result| result["Doc"] }
+    end
+
+    # Ask a question and return the answer
+    # @param question [String] The question to ask
+    # @param k [Integer] The number of results to have in context
+    # @yield [String] Stream responses back one String at a time
+    # @return [String] The answer to the question
+    def ask(question:, k: 4, &block)
+      search_results = similarity_search(query: question, k: k)
+
+      context = search_results.map do |result|
+        result.to_s
+      end
+      context = context.join("\n---\n")
+
+      prompt = generate_rag_prompt(question: question, context: context)
+
+      response = llm.chat(prompt: prompt, &block)
+      response.context = context
+      response
+    end
+  end
+end

--- a/spec/langchain/vectorsearch/epsilla_spec.rb
+++ b/spec/langchain/vectorsearch/epsilla_spec.rb
@@ -73,6 +73,15 @@ if ENV["EPSILLA_HOST"]
         expect(result["statusCode"]).to eq(200)
       end
 
+      it "adds texts with IDs" do
+        result = subject.add_texts(texts: ["Hello World", "Hello World"], ids: [100, 101])
+        expect(result["statusCode"]).to eq(200)
+      end
+
+      it "raises when text and ids have different lengths" do
+        expect { subject.add_texts(texts: ["Hello World", "Hello World"], ids: [100]) }.to raise_error("The number of ids must match the number of texts")
+      end
+
       after do
         subject.destroy_default_schema
       end

--- a/spec/langchain/vectorsearch/epsilla_spec.rb
+++ b/spec/langchain/vectorsearch/epsilla_spec.rb
@@ -2,14 +2,13 @@
 
 require "epsilla"
 
-if ENV["EPSILLA_HOST"]
+if ENV["EPSILLA_URL"]
   RSpec.describe Langchain::Vectorsearch::Epsilla do
     let(:index_name) { "documents" }
 
     subject {
       described_class.new(
-        protocol: "http",
-        host: ENV["EPSILLA_HOST"],
+        url: ENV["EPSILLA_URL"],
         index_name: index_name,
         db_name: "langchainrb_tests",
         db_path: "/tmp/langchainrb_tests",

--- a/spec/langchain/vectorsearch/epsilla_spec.rb
+++ b/spec/langchain/vectorsearch/epsilla_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+require "epsilla"
+
+if ENV["EPSILLA_HOST"]
+  RSpec.describe Langchain::Vectorsearch::Epsilla do
+    let(:index_name) { "documents" }
+
+    subject {
+      described_class.new(
+        protocol: "http",
+        host: ENV["EPSILLA_HOST"],
+        index_name: index_name,
+        db_name: "langchainrb_tests",
+        db_path: "/tmp/langchainrb_tests",
+        llm: Langchain::LLM::OpenAI.new(api_key: "123")
+      )
+    }
+
+    describe "#create_default_schema" do
+      before do
+        # clean up
+        subject.destroy_default_schema
+      rescue
+        # do nothing
+      end
+
+      it "returns 200 OK" do
+        expect(subject.create_default_schema["statusCode"]).to eq(200)
+      end
+    end
+
+    describe "#destroy_default_schema" do
+      before do
+        subject.create_default_schema
+      rescue
+        # do nothing
+      end
+
+      it "returns 200 OK" do
+        expect(subject.destroy_default_schema["statusCode"]).to eq(200)
+      end
+    end
+
+    describe "#add_texts" do
+      before do
+        allow_any_instance_of(
+          OpenAI::Client
+        ).to receive(:embeddings)
+          .with(
+            parameters: {
+              model: "text-embedding-ada-002",
+              input: "Hello World"
+            }
+          )
+          .and_return({
+            "object" => "list",
+            "data" => [
+              {"embedding" => 1536.times.map { rand }}
+            ]
+          })
+
+        begin
+          # make sure table is created
+          subject.create_default_schema
+        rescue
+          # do nothing
+        end
+      end
+
+      it "adds texts" do
+        result = subject.add_texts(texts: ["Hello World", "Hello World"])
+        expect(result["statusCode"]).to eq(200)
+      end
+
+      after do
+        subject.destroy_default_schema
+      end
+    end
+
+    describe "#similarity_search" do
+      before do
+        allow_any_instance_of(
+          OpenAI::Client
+        ).to receive(:embeddings)
+          .with(
+            parameters: {
+              model: "text-embedding-ada-002",
+              input: "earth"
+            }
+          )
+          .and_return({
+            "object" => "list",
+            "data" => [
+              {"embedding" => 1536.times.map { 0 }}
+            ]
+          })
+
+        allow_any_instance_of(
+          OpenAI::Client
+        ).to receive(:embeddings)
+          .with(
+            parameters: {
+              model: "text-embedding-ada-002",
+              input: "something about earth"
+            }
+          )
+          .and_return({
+            "object" => "list",
+            "data" => [
+              {"embedding" => 1536.times.map { 0 }}
+            ]
+          })
+
+        4.times do |i|
+          allow_any_instance_of(
+            OpenAI::Client
+          ).to receive(:embeddings)
+            .with(
+              parameters: {
+                model: "text-embedding-ada-002",
+                input: "Hello World #{i}"
+              }
+            )
+            .and_return({
+              "object" => "list",
+              "data" => [
+                {"embedding" => 1536.times.map { rand }}
+              ]
+            })
+        end
+
+        begin
+          # make sure table is created
+          subject.create_default_schema
+        rescue
+          # do nothing
+        end
+
+        subject.add_texts(texts: ["something about earth"])
+        subject.add_texts(texts: [0, 1, 2, 3].map { |i| "Hello World #{i}" })
+      end
+
+      it "searches for similar texts" do
+        result = subject.similarity_search(query: "earth")
+
+        expect(result.first).to eq("something about earth")
+      end
+
+      it "searches for similar vectors" do
+        result = subject.similarity_search_by_vector(embedding: 1536.times.map { 0 })
+
+        expect(result.count).to eq(4)
+        expect(result.first).to eq("something about earth")
+      end
+
+      after do
+        subject.destroy_default_schema
+      end
+    end
+
+    describe "#ask" do
+      let(:question) { "How many times is 'lorem' mentioned in this text?" }
+      let(:text) { "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor." }
+      let(:prompt) { "Context:\n#{text}\n---\nQuestion: #{question}\n---\nAnswer:" }
+      let(:response) { double(completion: answer) }
+      let(:answer) { "5 times" }
+      let(:k) { 4 }
+
+      before do
+        allow_any_instance_of(
+          OpenAI::Client
+        ).to receive(:embeddings)
+          .with(
+            parameters: {
+              model: "text-embedding-ada-002",
+              input: question
+            }
+          )
+          .and_return({
+            "object" => "list",
+            "data" => [
+              {"embedding" => 1536.times.map { 0 }}
+            ]
+          })
+        allow_any_instance_of(
+          OpenAI::Client
+        ).to receive(:embeddings)
+          .with(
+            parameters: {
+              model: "text-embedding-ada-002",
+              input: text
+            }
+          )
+          .and_return({
+            "object" => "list",
+            "data" => [
+              {"embedding" => 1536.times.map { 0 }}
+            ]
+          })
+      end
+
+      before do
+        begin
+          # make sure table is created
+          subject.create_default_schema
+        rescue
+          # do nothing
+        end
+
+        subject.add_texts(texts: [text])
+      end
+
+      context "without block" do
+        before do
+          allow(subject.llm).to receive(:chat).with(prompt: prompt).and_return(response)
+          expect(response).to receive(:context=).with(text)
+        end
+
+        it "asks a question and returns the answer" do
+          expect(subject.ask(question: question, k: k).completion).to eq(answer)
+        end
+      end
+
+      context "with block" do
+        let(:block) { proc { |chunk| puts "Received chunk: #{chunk}" } }
+
+        before do
+          allow(subject.llm).to receive(:chat) do |parameters|
+            if parameters[:prompt] == prompt && parameters[:stream].is_a?(Proc)
+              parameters[:stream].call("Received chunk from llm.chat")
+            end
+          end
+        end
+
+        it "asks a question and yields the chunk to the block" do
+          expect do
+            captured_output = capture(:stdout) do
+              subject.ask(question: question, &block)
+            end
+            expect(captured_output).to match(/Received chunk from llm.chat/)
+          end
+        end
+      end
+
+      after do
+        subject.destroy_default_schema
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a database connector to [Epsilla](https://github.com/epsilla-cloud/vectordb), an open source vector database. It allows langchainrb users to use it with the unified interface that currently supports a few others.

### Testing
I added unit tests that run along with the official Epsilla docker container.

