### PR TITLE
fix: fix parser needs the actual completion

### DIFF
--- a/lib/langchain/output_parsers/output_fixing_parser.rb
+++ b/lib/langchain/output_parsers/output_fixing_parser.rb
@@ -58,7 +58,7 @@ module Langchain::OutputParsers
           completion: completion,
           error: e
         )
-      )
+      ).completion
       parser.parse(new_completion)
     end
 


### PR DESCRIPTION
## Description

The README examples of the `OutputFixingParser` don't work when the initial response is invalid json and needs fixing:

```ruby
fix_parser = Langchain::OutputParsers::OutputFixingParser.from_llm(
  llm: llm,
  parser: parser
)
fix_parser.parse(llm_response)
```

results in:

```
ruby-3.2.2/gems/langchainrb-0.7.5/lib/langchain/output_parsers/structured_output_parser.rb:78:in `rescue in parse': Failed to parse. Text: "#<Langchain::LLM::OpenAIResponse:0x000000010a2c1630>". Error: undefined method `include?' for #<Langchain::LLM::OpenAIResponse:0x000000010a2c1630...
```

where as the previous example includes a `.completion`:
```ruby
llm = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
llm_response = llm.chat(prompt: prompt_text).completion
parser.parse(llm_response)
```

which is the reference for this PR. I'm not sure how to fix the tests yet - I could use some pointers or help.


## Extended Example
```ruby
## taken from the README
json_schema = {
  type: "object",
  properties: {
    name: {
      type: "string",
      description: "Persons name"
    },
    age: {
      type: "number",
      description: "Persons age"
    },
    interests: {
      type: "array",
      items: {
        type: "object",
        properties: {
          interest: {
            type: "string",
            description: "A topic of interest"
          },
          levelOfInterest: {
            type: "number",
            description: "A value between 0 and 100 of how interested the person is in this interest"
          }
        },
        required: ["interest", "levelOfInterest"],
        additionalProperties: false
      },
      minItems: 1,
      maxItems: 3,
      description: "A list of the person's interests"
    }
  },
  required: ["name", "age", "interests"],
  additionalProperties: false
}
llm = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
parser = Langchain::OutputParsers::StructuredOutputParser.from_json_schema(json_schema)
fix_parser = Langchain::OutputParsers::OutputFixingParser.from_llm(
  llm: llm,
  parser: parser
)

## This response is poorly formed, first "interest" is a color
bad_response =<<EOF
{
  "name": "Ji-hyun Kim",
  "age": 21,
  "interests": [
    {
      "color": "Red",
    },
    {
      "interest": "Physical Chemistry",
      "levelOfInterest": 70
    },
    {
      "interest": "Analytical Chemistry",
      "levelOfInterest": 60
    }
  ]
}
EOF

## rather than succeed in prompting the llm to fix the json, it will blow up with the error above
fix_parser.parse(bad_response)

```

