### PR TITLE
Fix completion method for Ollama

### DIFF
--- a/lib/langchain/llm/response/ollama_response.rb
+++ b/lib/langchain/llm/response/ollama_response.rb
@@ -8,7 +8,7 @@ module Langchain::LLM
     end
 
     def completion
-      raw_response.first
+      completions.first
     end
 
     def completions


### PR DESCRIPTION
Using the `ollama` LLM, the `completion` method produces an error.

Code:
```ruby
ollama = Langchain::LLM::Ollama.new(
  url: 'http://localhost:11434'
)
puts ollama.complete(
  model: 'mistral',
  prompt: 'In one word, what is the capital of France?'
).completion
```

Output:
```
/home/paul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/langchainrb-0.8.1/lib/langchain/llm/response/ollama_response.rb:11:in `completion': undefined method `first' for "\nParis":String (NoMethodError)
```

I believe this ought to return either just the complete `raw_response` string, or the first item of the `completions` array, similar to the code for this response:
https://github.com/andreibondarev/langchainrb/blob/main/lib/langchain/llm/response/replicate_response.rb#L12C7-L12C7

To clarify, the `#completions` method works as expected.

Please correct me if I'm misinterpreting anything, but this fix worked for me!