### PR TITLE
Allow Specifying Chunker

### DIFF
--- a/lib/langchain/data.rb
+++ b/lib/langchain/data.rb
@@ -12,6 +12,7 @@ module Langchain
     def initialize(data, options = {})
       @source = options[:source]
       @data = data
+      @chunker_klass = options[:chunker] || Langchain::Chunker::Text
     end
 
     # @return [String]
@@ -22,7 +23,7 @@ module Langchain
     # @param opts [Hash] options passed to the chunker
     # @return [Array<String>]
     def chunks(opts = {})
-      Langchain::Chunker::Text.new(@data, **opts).chunks
+      @chunker_klass.new(@data, **opts).chunks
     end
   end
 end

--- a/lib/langchain/data.rb
+++ b/lib/langchain/data.rb
@@ -9,10 +9,10 @@ module Langchain
 
     # @param data [String] data that was loaded
     # @option options [String] :source URL or Path of the data source
-    def initialize(data, options = {})
-      @source = options[:source]
+    def initialize(data, source: nil, chunker: Langchain::Chunker::Text)
+      @source = source
       @data = data
-      @chunker_klass = options[:chunker] || Langchain::Chunker::Text
+      @chunker_klass = chunker
     end
 
     # @return [String]

--- a/lib/langchain/loader.rb
+++ b/lib/langchain/loader.rb
@@ -112,7 +112,7 @@ module Langchain
         processor_klass.new(@options).parse(@raw_data)
       end
 
-      Langchain::Data.new(result)
+      Langchain::Data.new(result, @options)
     end
 
     def processor_klass

--- a/lib/langchain/loader.rb
+++ b/lib/langchain/loader.rb
@@ -37,9 +37,10 @@ module Langchain
     # @param path [String | Pathname] path to file or URL
     # @param options [Hash] options passed to the processor class used to process the data
     # @return [Langchain::Loader] loader instance
-    def initialize(path, options = {})
+    def initialize(path, options = {}, chunker: Langchain::Chunker::Text)
       @options = options
       @path = path
+      @chunker = chunker
     end
 
     # Is the path a URL?
@@ -112,7 +113,7 @@ module Langchain
         processor_klass.new(@options).parse(@raw_data)
       end
 
-      Langchain::Data.new(result, @options)
+      Langchain::Data.new(result, source: @options[:source], chunker: @chunker)
     end
 
     def processor_klass

--- a/lib/langchain/vectorsearch/base.rb
+++ b/lib/langchain/vectorsearch/base.rb
@@ -175,13 +175,13 @@ module Langchain::Vectorsearch
       prompt_template.format(question: question, context: context)
     end
 
-    def add_data(paths:)
+    def add_data(paths:, options: {})
       raise ArgumentError, "Paths must be provided" if Array(paths).empty?
 
       texts = Array(paths)
         .flatten
         .map do |path|
-          data = Langchain::Loader.new(path)&.load&.chunks
+          data = Langchain::Loader.new(path, options)&.load&.chunks
           data.map { |chunk| chunk.text }
         end
 

--- a/lib/langchain/vectorsearch/base.rb
+++ b/lib/langchain/vectorsearch/base.rb
@@ -181,7 +181,7 @@ module Langchain::Vectorsearch
       texts = Array(paths)
         .flatten
         .map do |path|
-          data = Langchain::Loader.new(path, options, chunker:)&.load&.chunks
+          data = Langchain::Loader.new(path, options, chunker: chunker)&.load&.chunks
           data.map { |chunk| chunk.text }
         end
 

--- a/lib/langchain/vectorsearch/base.rb
+++ b/lib/langchain/vectorsearch/base.rb
@@ -175,13 +175,13 @@ module Langchain::Vectorsearch
       prompt_template.format(question: question, context: context)
     end
 
-    def add_data(paths:, options: {})
+    def add_data(paths:, options: {}, chunker: Langchain::Chunker::Text)
       raise ArgumentError, "Paths must be provided" if Array(paths).empty?
 
       texts = Array(paths)
         .flatten
         .map do |path|
-          data = Langchain::Loader.new(path, options)&.load&.chunks
+          data = Langchain::Loader.new(path, options, chunker:)&.load&.chunks
           data.map { |chunk| chunk.text }
         end
 

--- a/spec/langchain/data_spec.rb
+++ b/spec/langchain/data_spec.rb
@@ -16,5 +16,19 @@ RSpec.describe Langchain::Data do
       expect(chunks[1].text).to eq(split_data[1])
       expect(chunks[2].text).to eq(split_data[2])
     end
+
+    context "with an optional chunker class" do
+      subject { described_class.new(data, source: source, chunker: Langchain::Chunker::RecursiveText) }
+      let(:chunker) { instance_double(Langchain::Chunker::RecursiveText) }
+
+      before do
+        expect(Langchain::Chunker::RecursiveText).to receive(:new).and_return(chunker)
+      end
+
+      it "uses an optional chunker class" do
+        expect(chunker).to receive(:chunks)
+        subject.chunks
+      end
+    end
   end
 end

--- a/spec/langchain/loader_spec.rb
+++ b/spec/langchain/loader_spec.rb
@@ -281,6 +281,19 @@ RSpec.describe Langchain::Loader do
       end
     end
 
+    context "with an optional chunker class" do
+      subject do
+        described_class.new(path, {chunker: Langchain::Chunker::RecursiveText})
+      end
+
+      let(:path) { "http://example.com/example.txt" }
+
+      it "passes an optional chunker class to Langchain::Data" do
+        expect(Langchain::Data).to receive(:new).with(instance_of(String), {chunker: Langchain::Chunker::RecursiveText})
+        subject.load
+      end
+    end
+
     context "Unsupported file type" do
       context "from local file" do
         let(:path) { "spec/fixtures/loaders/example.swf" }

--- a/spec/langchain/loader_spec.rb
+++ b/spec/langchain/loader_spec.rb
@@ -283,13 +283,13 @@ RSpec.describe Langchain::Loader do
 
     context "with an optional chunker class" do
       subject do
-        described_class.new(path, {chunker: Langchain::Chunker::RecursiveText})
+        described_class.new(path, chunker: Langchain::Chunker::RecursiveText)
       end
 
       let(:path) { "http://example.com/example.txt" }
 
       it "passes an optional chunker class to Langchain::Data" do
-        expect(Langchain::Data).to receive(:new).with(instance_of(String), {chunker: Langchain::Chunker::RecursiveText})
+        expect(Langchain::Data).to receive(:new).with(instance_of(String), chunker: Langchain::Chunker::RecursiveText, source: nil)
         subject.load
       end
     end

--- a/spec/langchain/vectorsearch/base_spec.rb
+++ b/spec/langchain/vectorsearch/base_spec.rb
@@ -126,9 +126,9 @@ RSpec.describe Langchain::Vectorsearch::Base do
       let(:paths) { Langchain.root.join("../spec/fixtures/loaders/example.txt") }
 
       it "passes an optional chunker class to Langchain::Loader", :aggregate_failures do
-        expect(Langchain::Loader).to receive(:new).with(paths, {chunker: Langchain::Chunker::RecursiveText}).and_call_original
+        expect(Langchain::Loader).to receive(:new).with(paths, {}, chunker: Langchain::Chunker::RecursiveText).and_call_original
         # #add_data will raise NotImplementedError when it calls #add_texts, this is expected and ignored in this test
-        expect { subject.add_data(paths: paths, options: {chunker: Langchain::Chunker::RecursiveText}) }.to raise_error(NotImplementedError)
+        expect { subject.add_data(paths: paths, chunker: Langchain::Chunker::RecursiveText) }.to raise_error(NotImplementedError)
       end
     end
   end

--- a/spec/langchain/vectorsearch/base_spec.rb
+++ b/spec/langchain/vectorsearch/base_spec.rb
@@ -117,5 +117,19 @@ RSpec.describe Langchain::Vectorsearch::Base do
     it "requires paths" do
       expect { subject.add_data(paths: []) }.to raise_error(ArgumentError, /Paths must be provided/)
     end
+
+    context "with an optional chunker class" do
+      subject do
+        described_class.new(llm: Langchain::LLM::OpenAI.new(api_key: "123"))
+      end
+
+      let(:paths) { Langchain.root.join("../spec/fixtures/loaders/example.txt") }
+
+      it "passes an optional chunker class to Langchain::Loader", :aggregate_failures do
+        expect(Langchain::Loader).to receive(:new).with(paths, {chunker: Langchain::Chunker::RecursiveText}).and_call_original
+        # #add_data will raise NotImplementedError when it calls #add_texts, this is expected and ignored in this test
+        expect { subject.add_data(paths: paths, options: {chunker: Langchain::Chunker::RecursiveText}) }.to raise_error(NotImplementedError)
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently `Langchain::Data` is hardcoded to use `Langchain::Chunker::Text` when chunking data. This PR allows a different Chunker to be passed in as an option. It also allows passing the Chunker in to `Langchain::Loader` and to be specified when calling `Langchain::Vectorsearch#add_data`.

Specs have been added for this behavior.
