### PR TITLE
Add standard-custom to Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
 
 require:
   - standard
+  - standard-custom
   - rubocop-performance
 
 inherit_gem:


### PR DESCRIPTION
`standard-custom` wasn't included in the *required* section of `standard-custom` causing:

> Error: unrecognized cop or department Standard/BlockSingleLineBraces

when running Rubocop.
