### PR TITLE
Fix OpenAI Invalid value for "tool_choice"

### DIFF
--- a/lib/langchain/llm/openai.rb
+++ b/lib/langchain/llm/openai.rb
@@ -133,7 +133,7 @@ module Langchain::LLM
       parameters[:temperature] = temperature if temperature
       parameters[:top_p] = top_p if top_p
       parameters[:tools] = tools if tools.any?
-      parameters[:tool_choice] = tool_choice if tool_choice
+      parameters[:tool_choice] = tool_choice if tools.any? && tool_choice
       parameters[:user] = user if user
 
       # TODO: Clean this part up


### PR DESCRIPTION
This is to fix the following error, only pass tool_choice if tools are present

```
Langchain::LLM::ApiError: OpenAI API error: Invalid value for 'tool_choice': 'tool_choice' is only allowed when 'tools' are specified.
```