### PR TITLE
Update openai_validator.rb for gpt-4-1106-preview

### DIFF
--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -40,6 +40,7 @@ module Langchain
           "gpt-4-32k-0314" => 32768,
           "gpt-4-32k-0613" => 32768,
           "gpt-4-1106-preview" => 128000,
+          "gpt-4-0125-preview" => 128000,
           "gpt-4-vision-preview" => 128000,
           "text-curie-001" => 2049,
           "text-babbage-001" => 2049,


### PR DESCRIPTION
This PR appends the new model name to the list.

**Also note:** This from the [OpenAI model announcement](https://openai.com/blog/new-embedding-models-and-api-updates):

> For those who want to be automatically upgraded to new GPT-4 Turbo preview versions, we are also introducing a new `gpt-4-turbo-preview` model name alias, which will always point to our latest GPT-4 Turbo preview model.

Being unsure how you want to handle this, I did not add `gpt-4-turbo-preview`. LMK if you want another PR for that.