### PR TITLE
Adding support for new embedding models + adding missing base_uri parameter for pinecone

### DIFF
--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -42,6 +42,8 @@ module Langchain
           "gpt-4-32k-0314" => 32768,
           "gpt-4-32k-0613" => 32768,
           "gpt-4-1106-preview" => 128000,
+          "gpt-4-0125-preview" => 128000,
+          "gpt-4-turbo-preview" => 128000,
           "gpt-4-vision-preview" => 128000,
           "text-curie-001" => 2049,
           "text-babbage-001" => 2049,

--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -23,6 +23,8 @@ module Langchain
           # Source:
           # https://platform.openai.com/docs/api-reference/embeddings
           # https://platform.openai.com/docs/models/gpt-4
+          "text-embedding-3-large" => 8191,
+          "text-embedding-3-small" => 8191,
           "text-embedding-ada-002" => 8191,
           "gpt-3.5-turbo" => 4096,
           "gpt-3.5-turbo-0301" => 4096,

--- a/lib/langchain/utils/token_length/openai_validator.rb
+++ b/lib/langchain/utils/token_length/openai_validator.rb
@@ -60,6 +60,11 @@ module Langchain
         # @return [Integer] The token length of the text
         #
         def self.token_length(text, model_name, options = {})
+          # tiktoken-ruby doesn't support text-embedding-3-large or text-embedding-3-small yet
+          if ['text-embedding-3-large', 'text-embedding-3-small'].include?(model_name)
+            model_name = 'text-embedding-ada-002'
+          end
+
           encoder = Tiktoken.encoding_for_model(model_name)
           encoder.encode(text).length
         end

--- a/lib/langchain/vectorsearch/pinecone.rb
+++ b/lib/langchain/vectorsearch/pinecone.rb
@@ -17,12 +17,13 @@ module Langchain::Vectorsearch
     # @param api_key [String] The API key to use
     # @param index_name [String] The name of the index to use
     # @param llm [Object] The LLM client to use
-    def initialize(environment:, api_key:, index_name:, llm:)
+    def initialize(environment:, api_key:, base_uri:,  index_name:, llm:)
       depends_on "pinecone"
 
       ::Pinecone.configure do |config|
         config.api_key = api_key
         config.environment = environment
+        config.base_uri = base_uri
       end
 
       @client = ::Pinecone::Client.new


### PR DESCRIPTION
Adding support for text-embedding-3-large and text-embedding-3-small. 

PR contains a workaround for token length calculation, since TikToken does not yet support these new embedding models. 

Also fixed a missing "base_uri" parameter for Pinecone, which might be neccessary in some setups. 