### PR TITLE
Require Ollama LLM provider dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,6 +424,7 @@ DEPENDENCIES
   elasticsearch (~> 8.2.0)
   epsilla-ruby (~> 0.0.4)
   eqn (~> 1.6.5)
+  faraday
   google-apis-aiplatform_v1 (~> 0.7)
   google_palm_api (~> 0.1.3)
   google_search_results (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
     gem install langchainrb
 
+Additional gems may be required when loading LLM Providers. These are not included by default so you can include only what you need.
+
 ## Usage
 
 ```ruby

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -73,4 +73,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sequel", "~> 5.68.0"
   spec.add_development_dependency "weaviate-ruby", "~> 0.8.10"
   spec.add_development_dependency "wikipedia-client", "~> 1.17.0"
+  spec.add_development_dependency "faraday"
 end

--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -22,6 +22,7 @@ module Langchain::LLM
     # @param default_options [Hash] The default options to use
     #
     def initialize(url:, default_options: {})
+      depends_on "faraday"
       @url = url
       @defaults = DEFAULTS.merge(default_options)
     end


### PR DESCRIPTION
This change establishes Faraday as a required dependency for the Ollama LLM provider. Additionally, it starts to add documentation in the Readme that each of the LLMs may have their own dependencies that are not included by default.

Fixes #458 