### PR TITLE
Fix unknown keyword: :prompt (ArgumentError) in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ llm.complete(prompt: "What is the meaning of life?").completion
 
 Generate a chat completion:
 ```ruby
-llm.chat(prompt: "Hey! How are you?").completion
+llm.chat(messages: [{role: "user", content: "What is the meaning of life?"}]).completion
 ```
 
 Summarize the text:


### PR DESCRIPTION
When running the Generate a chat completion example, I encountered an unknown keyword: :prompt (ArgumentError) error.

```
$  bundle exec irb
irb(main):001:0> require "langchain"
=> true
irb(main):002:0> llm = Langchain::LLM::OpenAI.new(api_key: ENV["OPENAI_API_KEY"])
=>
#<Langchain::LLM::OpenAI:0x00000001030c20e8
...
irb(main):003:0> llm.chat(prompt: "Hey! How are you?").completion
/Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/langchainrb-0.9.0/lib/langchain/llm/openai.rb:93:in `chat': unknown keyword: :prompt (ArgumentError)
        from (irb):3:in `<main>'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from /Users/hazumi/.rbenv/versions/3.1.2/bin/irb:25:in `load'
        from /Users/hazumi/.rbenv/versions/3.1.2/bin/irb:25:in `<top (required)>'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/cli/exec.rb:58:in `load'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/cli/exec.rb:58:in `kernel_load'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/cli/exec.rb:23:in `run'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/cli.rb:492:in `exec'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/cli.rb:34:in `dispatch'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/cli.rb:28:in `start'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/exe/bundle:37:in `block in <top (required)>'
        from /Users/hazumi/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.4.21/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        ... 3 levels...
```

Upon reviewing the code, it appears that the interface and the example code do not match, so I would like to make the necessary corrections.

https://github.com/andreibondarev/langchainrb/blob/1e6c934293c9545f3cab98c9bae6749e5722d7bd/lib/langchain/llm/openai.rb#L93-L113
https://github.com/andreibondarev/langchainrb/blob/1e6c934293c9545f3cab98c9bae6749e5722d7bd/README.md?plain=1#L96

I suggest making adjustments to the arguments in the example code.