### PR TITLE
Allow json-schema 4.1

### DIFF
--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "baran", "~> 0.1.9"
   spec.add_dependency "colorize", "~> 1.1.0"
   spec.add_dependency "tiktoken_ruby", "~> 0.0.7"
-  spec.add_dependency "json-schema", "~> 4.0.0"
+  spec.add_dependency "json-schema", "~> 4"
   spec.add_dependency "zeitwerk", "~> 2.5"
   spec.add_dependency "pragmatic_segmenter", "~> 0.3.0"
   spec.add_dependency "to_bool", "~> 2.0.0"


### PR DESCRIPTION
In order to add to our gemset, we need langchainrb to loosen their dependency restrictions.  json-schema 4.0 was good but 4.1 is also compatible.  By reducing the zeros in the pessimistic lock, the minor version can rise without allowing 5.x versions.