### PR TITLE
Fix errors when run spec only ollama_spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     langchainrb (0.9.3)
+      activesupport (~> 7.1.3)
       baran (~> 0.1.9)
       colorize (~> 1.1.0)
       json-schema (~> 4)

--- a/langchain.gemspec
+++ b/langchain.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   # dependencies
   # Not sure if we should require this as it only applies to OpenAI usecase.
+  spec.add_dependency "activesupport", "~> 7.1.3"
   spec.add_dependency "baran", "~> 0.1.9"
   spec.add_dependency "colorize", "~> 1.1.0"
   spec.add_dependency "tiktoken_ruby", "~> 0.0.7"

--- a/lib/langchain/llm/ollama.rb
+++ b/lib/langchain/llm/ollama.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/hash"
+
 module Langchain::LLM
   # Interface to Ollama API.
   # Available models: https://ollama.ai/library


### PR DESCRIPTION
fix #493 

Added a dependency on ActiveSupport to gemspec and explicitly required an ActiveSupport Hash in `ollama.rb`Added a dependency on ActiveSupport to gemspec and explicitly required an ActiveSupport Hash in ollama.rb.
(The dependency on ActiveSupport itself originally existed via ActionPack, etc., but since it uses `deep_merge` directly, the direct dependency should be made explicit.)

We can enable ActiveSupport for the whole project, but it seems from my research that the `deep_file` method is only used in this file, so I'm going with the least impactful way.

I confirmed that `rspec spec/langchain/llm/ollama_spec.rb` succeeds on this branch.
```
❯ bundle exec rspec spec/langchain/llm/ollama_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 18142

Langchain::LLM::Ollama
  #chat
    returns a chat completion
  #embed
    returns an embedding
  #complete
    returns a completion
  #default_dimension
    returns size of codellama embeddings
    returns size of mistral-openorca embeddings
    returns size of mistral embeddings
    returns size of llava embeddings
    returns size of tinydolphin embeddings
    returns size of dolphin-mixtral embeddings
    returns size of llama2 embeddings
    returns size of mixtral embeddings
  #initialize
    initializes the client without any errors
  #summarize
    returns a summarization

Finished in 0.08661 seconds (files took 0.75649 seconds to load)
13 examples, 0 failures
```